### PR TITLE
Fix -c flag not looking into the *bottom level folder

### DIFF
--- a/src/dfmt/editorconfig.d
+++ b/src/dfmt/editorconfig.d
@@ -132,9 +132,9 @@ EC getConfigFor(EC)(string path)
     EC[][] configs;
     immutable expanded = absolutePath(path);
     immutable bool id = isDir(expanded);
-    immutable string dir = dirName(expanded);
     immutable string fileName = id ? "dummy.d" : baseName(expanded);
-    string[] pathParts = cast(string[]) pathSplitter(dir).array();
+    string[] pathParts = cast(string[]) pathSplitter(expanded).array();
+
     for (size_t i = pathParts.length; i > 1; i--)
     {
         EC[] sections = parseConfig!EC(buildPath(pathParts[0 .. i]));


### PR DESCRIPTION
Dfmt was not checking .editorconfig presence in the *bottom level folder, when passing flag `-c C:/test/x`, it looked only into `test` and `C:`. This commit fixes it.