### PR TITLE
Add installing with DUB instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ when using the **--inplace** option.
 * To compile with DMD, run ```make``` in the dfmt directory. To compile with
   LDC, run ```make ldc``` instead. The generated binary will be placed in ```dfmt/bin/```.
 
+### Installing with DUB
+
+```sh
+> dub fetch --version='~master' dfmt && dub run dfmt -- -h
+```
 
 ## Using
 By default, dfmt reads its input from **stdin** and writes to **stdout**.


### PR DESCRIPTION
Unfortunately currently only the `~master` version builds with a recent DMD installation.