### PR TITLE
Add dmd-nightly and ldc-beta to the Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 sudo: false
 language: d
 d:
+  - dmd-nightly
   - dmd-beta
   - dmd
+  - ldc-beta
   - ldc
 
 os:


### PR DESCRIPTION
As discussed [here](https://github.com/dlang-community/discussions/issues/7), we can do our share to improve the D ecosystem stability. I have already enabled a daily cron job at Travis, s.t. this doesn't lead to random breakages on new PRs.