### PR TITLE
Set DUB config type to `autodetect`

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -1,7 +1,7 @@
 {
     "name": "dfmt",
     "description": "Dfmt is a formatter for D source code",
-    "targetType": "executable",
+    "targetType": "autodetect",
     "license": "BSL-1.0",
     "dependencies": {
       "libdparse": "~>0.7.1-beta.1"


### PR DESCRIPTION
This simple change and a new preview release tag afterwards is needed to integrate `dfmt` into the DLang Tour (https://github.com/stonemaster/dlang-tour/pull/516) (as a "Format" button).