### PR TITLE
Remove deprecated stdc import

### DIFF
--- a/tests/issue0114.d
+++ b/tests/issue0114.d
@@ -1,5 +1,5 @@
 private
 {
 	import std.process;
-	import std.c.windows.windows;
+	import core.sys.windows.windows;
 }


### PR DESCRIPTION
See also: https://github.com/dlang/phobos/pull/5532

I am doing this blindly (no Windows), but AppVeyor should be able to green-light this.