### PR TITLE
add --space_before_function_parameters

### DIFF
--- a/src/dfmt/config.d
+++ b/src/dfmt/config.d
@@ -44,6 +44,8 @@ struct Config
     ///
     OptionalBoolean dfmt_space_after_keywords;
     ///
+    OptionalBoolean dfmt_space_before_function_parameters;
+    ///
     OptionalBoolean dfmt_split_operator_at_line_end;
     ///
     OptionalBoolean dfmt_selective_import_space;
@@ -72,6 +74,7 @@ struct Config
         dfmt_soft_max_line_length = 80;
         dfmt_space_after_cast = OptionalBoolean.t;
         dfmt_space_after_keywords = OptionalBoolean.t;
+        dfmt_space_before_function_parameters = OptionalBoolean.f;
         dfmt_split_operator_at_line_end = OptionalBoolean.f;
         dfmt_selective_import_space = OptionalBoolean.t;
         dfmt_compact_labeled_statements = OptionalBoolean.t;

--- a/src/dfmt/formatter.d
+++ b/src/dfmt/formatter.d
@@ -281,6 +281,8 @@ private:
         {
             writeToken();
             if (index < tokens.length && (currentIs(tok!"identifier")
+                    || ( ( isBasicType(peekBack().type) || peekBackIs(tok!"identifier") ) &&
+                         currentIs(tok!("(")) && config.dfmt_space_before_function_parameters)
                     || isBasicType(current.type) || currentIs(tok!"@") || currentIs(tok!"if")
                     || isNumberLiteral(tokens[index].type) || (inAsm
                     && peekBack2Is(tok!";") && currentIs(tok!"["))))

--- a/src/dfmt/main.d
+++ b/src/dfmt/main.d
@@ -48,6 +48,9 @@ else
             case "space_after_cast":
                 optConfig.dfmt_space_after_cast = optVal;
                 break;
+            case "space_before_function_parameters":
+                optConfig.dfmt_space_before_function_parameters = optVal;
+		break;
             case "split_operator_at_line_end":
                 optConfig.dfmt_split_operator_at_line_end = optVal;
                 break;
@@ -80,6 +83,7 @@ else
                 "outdent_attributes", &handleBooleans,
                 "space_after_cast", &handleBooleans,
                 "selective_import_space", &handleBooleans,
+		"space_before_function_parameters", &handleBooleans,
                 "split_operator_at_line_end", &handleBooleans,
                 "compact_labeled_statements", &handleBooleans,
                 "tab_width", &optConfig.tab_width,
@@ -271,6 +275,7 @@ Formatting Options:
     --max_line_length
     --outdent_attributes
     --space_after_cast
+    --space_before_function_parameters
     --selective_import_space
     --split_operator_at_line_end
     --compact_labeled_statements


### PR DESCRIPTION
This pr adds the functionality to put a space before the function parameter / or template parameter list of a function definition.

without the option
```
void f(T)(T t)
{
}

my_type f()
{
}
```

with the option
```
void f (T)(T t)
{
}

my_type f ()
{
}
```
