### PR TITLE
Generate version-string from git-describe

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,8 +1,8 @@
 SRC := $(shell find src -name "*.d") \
 	$(shell find libdparse/src -name "*.d")
 INCLUDE_PATHS := -Ilibdparse/src -Isrc
-DMD_COMMON_FLAGS := -dip25 -w $(INCLUDE_PATHS)
-DMD_DEBUG_FLAGS := -g $(DMD_COMMON_FLAGS)
+DMD_COMMON_FLAGS := -dip25 -w $(INCLUDE_PATHS) -Jviews
+DMD_DEBUG_FLAGS := -debug -g $(DMD_COMMON_FLAGS)
 DMD_FLAGS := -O -inline $(DMD_COMMON_FLAGS)
 DMD_TEST_FLAGS := -unittest -g $(DMD_COMMON_FLAGS)
 LDC_FLAGS := -g -w -oq $(INCLUDE_PATHS)
@@ -14,6 +14,10 @@ GDC ?= gdc
 .PHONY: dmd ldc gdc test
 
 dmd: bin/dfmt
+
+views/VERSION : .git/refs/tags .git/HEAD
+	mkdir -p $(dir $@)
+	git describe --tags > $@
 
 ldc: $(SRC)
 	$(LDC) $(LDC_FLAGS) $^ -ofbin/dfmt
@@ -28,8 +32,9 @@ test: debug
 bin/dfmt-test: $(SRC)
 	$(DC) $(DMD_TEST_FLAGS) $^ -of$@
 
-bin/dfmt: $(SRC)
-	$(DC) $(DMD_FLAGS) $^ -of$@
+bin/dfmt: views/VERSION $(SRC)
+	$(DC) $(DMD_FLAGS) $(filter %.d,$^) -of$@
 
-debug: $(SRC)
-	$(DC) $(DMD_DEBUG_FLAGS) $^ -ofbin/dfmt
+debug: views/VERSION $(SRC)
+	$(DC) $(DMD_DEBUG_FLAGS) $(filter %.d,$^) -ofbin/dfmt
+

--- a/src/dfmt/main.d
+++ b/src/dfmt/main.d
@@ -4,8 +4,61 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 
 module dfmt.main;
+static immutable VERSION = () {
+    debug
+    {
+        enum DEBUG_SUFFIX = "-debug";
+    }
+    else
+    {
+        enum DEBUG_SUFFIX = "";
+    }
 
-private enum VERSION = "0.5.0";
+    static if (is(typeof(import("VERSION"))))
+    {
+        // takes the `git describe --tags` output and removes the leading
+        // 'v' as well as any kind of newline
+	// if the tag is considered malformed it gets used verbatim
+
+        enum gitDescribeOutput = import("VERSION");
+
+	string result;
+
+        if (gitDescribeOutput[0] == 'v')
+            result = gitDescribeOutput[1 .. $];
+        else
+            result = null;
+
+	uint minusCount;
+
+        foreach (i, c; result)
+        {
+            if (c == '\n' || c == '\r')
+            {
+                result = result[0 .. i];
+                break;
+            }
+
+	    if (c == '-')
+	    {
+                ++minusCount;
+            }
+        }
+
+        if (minusCount > 1)
+		result = null;
+
+        return result ? result ~ DEBUG_SUFFIX
+                      : gitDescribeOutput ~ DEBUG_SUFFIX;
+
+    }
+    else
+    {
+        return "unknown"  ~ DEBUG_SUFFIX ~ "-version";
+    }
+
+} ();
+
 
 version (NoMain)
 {


### PR DESCRIPTION
- adds make target for `views/VERSION` which uses git describe to get the version number
- string imports `views/VERSION` if available and uses it as version-string
- `-debug` is added if in debug