### PR TITLE
Sbfp fix

### DIFF
--- a/src/dfmt/ast_info.d
+++ b/src/dfmt/ast_info.d
@@ -30,6 +30,7 @@ struct ASTInformation
         sort(arrayStartLocations);
         sort(contractLocations);
         sort(constraintLocations);
+        sort(constructorDestructorLocations);
     }
 
     /// Locations of end braces for struct bodies
@@ -73,6 +74,9 @@ struct ASTInformation
 
     /// Locations of template constraint "if" tokens
     size_t[] constraintLocations;
+
+    /// Locations of constructor/destructor "this" tokens ?
+    size_t[] constructorDestructorLocations;
 }
 
 /// Collects information from the AST that is useful for the formatter
@@ -91,6 +95,18 @@ final class FormatVisitor : ASTVisitor
     {
         astInformation.arrayStartLocations ~= arrayInitializer.startLocation;
         arrayInitializer.accept(this);
+    }
+
+    override void visit(const Constructor constructor)
+    {
+        astInformation.constructorDestructorLocations ~= constructor.location;
+        constructor.accept(this);
+    }
+
+    override void visit(const Destructor destructor)
+    {
+        astInformation.constructorDestructorLocations ~= destructor.index;
+        destructor.accept(this);
     }
 
     override void visit(const ConditionalDeclaration dec)

--- a/src/dfmt/formatter.d
+++ b/src/dfmt/formatter.d
@@ -1,3 +1,4 @@
+
 //          Copyright Brian Schott 2015.
 // Distributed under the Boost Software License, Version 1.0.
 //    (See accompanying file LICENSE.txt or copy at
@@ -263,6 +264,17 @@ private:
                 inAsm = false;
             }
         }
+        else if (currentIs(tok!"this"))
+        {
+            const thisIndex = current.index;
+            formatKeyword();
+            if (config.dfmt_space_before_function_parameters
+                && astInformation.constructorDestructorLocations
+                    .canFindIndex(thisIndex))
+            {
+                write(" ");
+            }
+        }
         else if (isKeyword(current.type))
         {
             formatKeyword();
@@ -280,12 +292,19 @@ private:
         else if (currentIs(tok!"identifier"))
         {
             writeToken();
-            if (index < tokens.length && (currentIs(tok!"identifier")
-                    || ( index > 1 && ( isBasicType(peekBack(2).type) || peekBack2Is(tok!"identifier") ) &&
-                         currentIs(tok!("(")) && config.dfmt_space_before_function_parameters )
+            //dfmt off
+            if (index < tokens.length && ( currentIs(tok!"identifier")
+                    || ( index > 1 && config.dfmt_space_before_function_parameters
+                        && ( isBasicType(peekBack(2).type)
+                            || peekBack2Is(tok!"identifier")
+                            || peekBack2Is(tok!")")
+                            || peekBack2Is(tok!"]") )
+                        && currentIs(tok!("(") )
                     || isBasicType(current.type) || currentIs(tok!"@") || currentIs(tok!"if")
-                    || isNumberLiteral(tokens[index].type) || (inAsm
-                    && peekBack2Is(tok!";") && currentIs(tok!"["))))
+                    || isNumberLiteral(tokens[index].type)
+                    || (inAsm  && peekBack2Is(tok!";") && currentIs(tok!"["))
+            )))
+            //dfmt on
             {
                 write(" ");
             }


### PR DESCRIPTION
This fixes the --space-before-function-paramters to also work on functions returning slices and to also put the space on constructors which are functions as well.