### PR TITLE
Put a space behind static and shared constructors as well

### DIFF
--- a/src/dfmt/ast_info.d
+++ b/src/dfmt/ast_info.d
@@ -31,6 +31,8 @@ struct ASTInformation
         sort(contractLocations);
         sort(constraintLocations);
         sort(constructorDestructorLocations);
+        sort(staticConstructorDestructorLocations);
+        sort(sharedStaticConstructorDestructorLocations);
     }
 
     /// Locations of end braces for struct bodies
@@ -75,6 +77,12 @@ struct ASTInformation
     /// Locations of template constraint "if" tokens
     size_t[] constraintLocations;
 
+    /// Locations of constructor/destructor "shared" tokens ?
+    size_t[] sharedStaticConstructorDestructorLocations;
+
+    /// Locations of constructor/destructor "static" tokens ?
+    size_t[] staticConstructorDestructorLocations;
+
     /// Locations of constructor/destructor "this" tokens ?
     size_t[] constructorDestructorLocations;
 }
@@ -97,13 +105,37 @@ final class FormatVisitor : ASTVisitor
         arrayInitializer.accept(this);
     }
 
-    override void visit(const Constructor constructor)
+    override void visit (const SharedStaticConstructor sharedStaticConstructor)
+    {
+        astInformation.sharedStaticConstructorDestructorLocations ~= sharedStaticConstructor.location;
+        sharedStaticConstructor.accept(this);
+    }
+
+    override void visit (const SharedStaticDestructor sharedStaticDestructor)
+    {
+        astInformation.sharedStaticConstructorDestructorLocations ~= sharedStaticDestructor.location;
+        sharedStaticDestructor.accept(this);
+    }
+
+    override void visit (const StaticConstructor staticConstructor)
+    {
+        astInformation.staticConstructorDestructorLocations ~= staticConstructor.location;
+        staticConstructor.accept(this);
+    }
+
+    override void visit (const StaticDestructor staticDestructor)
+    {
+        astInformation.staticConstructorDestructorLocations ~= staticDestructor.location;
+        staticDestructor.accept(this);
+    }
+
+    override void visit (const Constructor constructor)
     {
         astInformation.constructorDestructorLocations ~= constructor.location;
         constructor.accept(this);
     }
 
-    override void visit(const Destructor destructor)
+    override void visit (const Destructor destructor)
     {
         astInformation.constructorDestructorLocations ~= destructor.index;
         destructor.accept(this);

--- a/src/dfmt/formatter.d
+++ b/src/dfmt/formatter.d
@@ -171,6 +171,9 @@ private:
     /// True if we're in an ASM block
     bool inAsm;
 
+    /// True if the next "this" should have a space behind it
+    bool thisSpace;
+
     void formatStep()
     {
         import std.range : assumeSorted;
@@ -269,10 +272,11 @@ private:
             const thisIndex = current.index;
             formatKeyword();
             if (config.dfmt_space_before_function_parameters
-                && astInformation.constructorDestructorLocations
-                    .canFindIndex(thisIndex))
+                && (thisSpace || astInformation.constructorDestructorLocations
+                    .canFindIndex(thisIndex)))
             {
                 write(" ");
+                thisSpace = false;
             }
         }
         else if (isKeyword(current.type))
@@ -1047,6 +1051,24 @@ private:
                     write(" ");
             }
             break;
+        case tok!"static":
+            {
+                if (astInformation.staticConstructorDestructorLocations
+                    .canFindIndex(current.index))
+                {
+                    thisSpace = true;
+                }
+            }
+            goto default;
+        case tok!"shared":
+            {
+                if (astInformation.sharedStaticConstructorDestructorLocations
+                    .canFindIndex(current.index))
+                {
+                    thisSpace = true;
+                }
+            }
+            goto default;
         default:
             if (peekBackIs(tok!"identifier"))
                 write(" ");


### PR DESCRIPTION
This is a change which allows to keep track of all kinds of contructors/destructors which in turn allows --space_before_function_parameters to work.