### PR TITLE
Make alias visit public in src/dfmt/ast_info.FormatVisitor

### DIFF
--- a/src/dfmt/ast_info.d
+++ b/src/dfmt/ast_info.d
@@ -90,6 +90,8 @@ struct ASTInformation
 /// Collects information from the AST that is useful for the formatter
 final class FormatVisitor : ASTVisitor
 {
+    alias visit = ASTVisitor.visit;
+
     /**
      * Params:
      *     astInformation = the AST information that will be filled in
@@ -295,5 +297,4 @@ final class FormatVisitor : ASTVisitor
 
 private:
     ASTInformation* astInformation;
-    alias visit = ASTVisitor.visit;
 }


### PR DESCRIPTION
Making the visiting alias private makes it so that the visit(Module) overload is not visible outside the FormatVisitor class. The code worked up until now due to a bug [1] in the compiler.

[1] dlang/dmd#7766