### PR TITLE
Switch to use the frozen stdx-allocator

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "beaver"]
 	path = beaver
 	url = https://github.com/sociomantic-tsunami/beaver.git
+[submodule "stdx-allocator"]
+	path = stdx-allocator
+	url = https://github.com/dlang-community/stdx-allocator

--- a/makefile
+++ b/makefile
@@ -1,6 +1,7 @@
 SRC := $(shell find src -name "*.d") \
-	$(shell find libdparse/src -name "*.d")
-INCLUDE_PATHS := -Ilibdparse/src -Isrc
+	$(shell find libdparse/src -name "*.d") \
+	$(shell find stdx-allocator/source -name "*.d")
+INCLUDE_PATHS := -Ilibdparse/src -Istdx-allocator/source -Isrc
 DMD_COMMON_FLAGS := -dip25 -w $(INCLUDE_PATHS) -Jviews
 DMD_DEBUG_FLAGS := -debug -g $(DMD_COMMON_FLAGS)
 DMD_FLAGS := -O -inline $(DMD_COMMON_FLAGS)


### PR DESCRIPTION
Required to be compatible with the new libdparse version - see https://github.com/dlang-community/libdparse/pull/211 and https://github.com/dlang-community/containers/pull/95