### PR TITLE
Fix Imports to point to the actual symbols rather then wrongly imported ones

### DIFF
--- a/src/dfmt/globmatch_editorconfig.d
+++ b/src/dfmt/globmatch_editorconfig.d
@@ -2,8 +2,9 @@ module dfmt.globmatch_editorconfig;
 
 import std.path : CaseSensitive;
 import std.range : isForwardRange, ElementEncodingType;
-import std.string : isSomeChar, isSomeString, empty, save, front, popFront;
-import std.typecons : Unqual;
+import std.traits : isSomeChar, isSomeString;
+import std.range.primitives :  empty, save, front, popFront;
+import std.traits : Unqual;
 import std.conv : to;
 import std.path : filenameCharCmp, isDirSeparator;
 

--- a/src/dfmt/main.d
+++ b/src/dfmt/main.d
@@ -188,7 +188,7 @@ else
         Config explicitConfig;
         if (explicitConfigDir)
         {
-            import std.path : exists, isDir;
+            import std.file : exists, isDir;
 
             if (!exists(explicitConfigDir) || !isDir(explicitConfigDir))
             {


### PR DESCRIPTION
There were a few imports which were taken from modules which are not the modules were they are defined in.

This PR fixes that.