### PR TITLE
Deploy binaries to GitHub releases (Windows/Linux/MacOS)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,3 +43,55 @@ jobs:
               on:
                   tags: true # must be a git tag
                   repo: dlang-community/dfmt # must be a tag on dlang-community
+        - stage: GitHub Release
+          #if: tag IS present
+          d: ldc-1.8.0
+          os: linux
+          script: echo "Deploying to GitHub releases ..." && ./release.sh
+          deploy:
+            provider: releases
+            api_key: $GH_REPO_TOKEN
+            file_glob: true
+            file: bin/dfmt-*.tar.gz
+            skip_cleanup: true
+            on:
+              repo: dlang-community/dfmt
+              tags: true
+        - stage: GitHub Release
+          #if: tag IS present
+          d: ldc-1.8.0
+          os: osx
+          script: echo "Deploying to GitHub releases ..." && ./release.sh
+          deploy:
+            provider: releases
+            api_key: $GH_REPO_TOKEN
+            file_glob: true
+            file: bin/dfmt-*.tar.gz
+            skip_cleanup: true
+            on:
+              repo: dlang-community/dfmt
+              tags: true
+        - stage: GitHub Release
+          #if: tag IS present
+          d: dmd
+          os: linux
+          language: generic
+          sudo: yes
+          script: echo "Deploying to GitHub releases ..." && ./release-windows.sh
+          addons:
+            apt:
+              packages:
+                - p7zip-full
+                - wine
+            deploy:
+              provider: releases
+              api_key: $GH_REPO_TOKEN
+              file_glob: true
+              file: bin/dfmt-.*.zip
+              skip_cleanup: true
+              on:
+                repo: dlang-community/dfmt
+                tags: true
+stages:
+  - name: test
+    if: type = pull_request or (type = push and branch = master)

--- a/makefile
+++ b/makefile
@@ -44,3 +44,6 @@ pkg: dmd
 
 clean:
 	$(RM) bin/dfmt
+
+release:
+	./release.sh

--- a/release-windows.sh
+++ b/release-windows.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Build the Windows binaries under Linux (requires wine)
+set -eux -o pipefail
+VERSION=$(git describe --abbrev=0 --tags)
+OS=windows
+ARCH_SUFFIX="x86"
+
+# Allow the script to be run from anywhere
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $DIR
+
+# Step 1: download the DMD binaries
+if [ ! -d dmd2 ] ; then
+	wget http://downloads.dlang.org/releases/2.x/2.079.0/dmd.2.079.0.windows.7z
+	7z x dmd.2.079.0.windows.7z > /dev/null
+fi
+
+# Step 2: Run DMD via wineconsole
+archiveName="dfmt-$VERSION-$OS-$ARCH_SUFFIX.zip"
+echo "Building $archiveName"
+mkdir -p bin
+DC="$DIR/dmd2/windows/bin/dmd.exe" wine cmd /C build.bat
+
+cd bin
+zip "$archiveName" dfmt.exe

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -eux -o pipefail
+VERSION=$(git describe --abbrev=0 --tags)
+ARCH="${ARCH:-64}"
+LDC_FLAGS=()
+unameOut="$(uname -s)"
+case "$unameOut" in
+    Linux*) OS=linux; LDC_FLAGS=("-flto=full" "-linker=gold" "-static") ;;
+    Darwin*) OS=osx; LDC_FLAGS+=("-L-macosx_version_min" "-L10.7" "-L-lcrt1.o"); ;;
+    *) echo "Unknown OS: $unameOut"; exit 1
+esac
+
+case "$ARCH" in
+    64) ARCH_SUFFIX="x86_64";;
+    32) ARCH_SUFFIX="x86";;
+    *) echo "Unknown ARCH: $ARCH"; exit 1
+esac
+
+archiveName="dfmt-$VERSION-$OS-$ARCH_SUFFIX.tar.gz"
+
+echo "Building $archiveName"
+${MAKE:-make} ldc LDC_FLAGS="${LDC_FLAGS[*]}"
+tar cvfz "bin/$archiveName" -C bin dfmt


### PR DESCRIPTION
Basically a copy of https://github.com/dlang-community/D-Scanner/pull/573 which itself is a copy of https://github.com/dlang/dub/pull/1369

(I already configured the environment variables `GH_REPO_TOKEN` on Travis - it's a bot account and the same we already use for e.g. deploying libdparse's documentation)