### PR TITLE
Update stdx alloc for future removal of std.c

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -4,7 +4,7 @@
     "targetType": "autodetect",
     "license": "BSL-1.0",
     "dependencies": {
-      "libdparse": "~>0.8.4"
+      "libdparse": "~>0.8.6"
     },
     "targetPath" : "bin/",
     "targetName" : "dfmt",


### PR DESCRIPTION
This PR removes the dependency to phobos `std.c`, which will be removed soon, see
https://github.com/dlang/phobos/pull/6515

This is a simple maintenance PR, expected to be merged quickly. The same have been done for D-Scanner or DCD, this week.
