### PR TITLE
Support for DIP1009 (new contracts syntax), #375

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -4,7 +4,7 @@
     "targetType": "autodetect",
     "license": "BSL-1.0",
     "dependencies": {
-      "libdparse": "~>0.8.6"
+      "libdparse": "~>0.9.7"
     },
     "targetPath" : "bin/",
     "targetName" : "dfmt",

--- a/src/dfmt/formatter.d
+++ b/src/dfmt/formatter.d
@@ -1048,7 +1048,7 @@ private:
             else if (peekBackIsKeyword)
                 write(" ");
             writeToken();
-            if (!currentIs(tok!"(") && !currentIs(tok!"{"))
+            if (!currentIs(tok!"(") && !currentIs(tok!"{") && !currentIs(tok!"comment"))
                 write(" ");
             break;
         case tok!"try":
@@ -1090,7 +1090,7 @@ private:
                     tok!"}", tok!"=", tok!"&&", tok!"||") && !peekBackIsKeyword())
                 write(" ");
             writeToken();
-            if (!currentIs(tok!"(") && !currentIs(tok!"{"))
+            if (!currentIs(tok!"(") && !currentIs(tok!"{") && !currentIs(tok!"comment"))
                 write(" ");
             break;
         case tok!"case":

--- a/src/dfmt/formatter.d
+++ b/src/dfmt/formatter.d
@@ -1906,7 +1906,7 @@ const pure @safe @nogc:
     bool isBlockHeaderToken(IdType t)
     {
         return t == tok!"for" || t == tok!"foreach" || t == tok!"foreach_reverse"
-            || t == tok!"while" || t == tok!"if" || t == tok!"out"
+            || t == tok!"while" || t == tok!"if" || t == tok!"in"|| t == tok!"out"
             || t == tok!"do" || t == tok!"catch" || t == tok!"with"
             || t == tok!"synchronized" || t == tok!"scope";
     }
@@ -1916,7 +1916,18 @@ const pure @safe @nogc:
         if (i + index < 0 || i + index >= tokens.length)
             return false;
         auto t = tokens[i + index].type;
-        return isBlockHeaderToken(t);
+        bool isExpressionContract;
+
+        if (i + index + 3 < tokens.length)
+        {
+            isExpressionContract = (t == tok!"in" && peekImplementation(tok!"(", i + 1, true))
+                || (t == tok!"out" && (peekImplementation(tok!"(", i + 1, true)
+                    && (peekImplementation(tok!";", i + 2, true)
+                        || (peekImplementation(tok!"identifier", i + 2, true)
+                            && peekImplementation(tok!";", i + 3, true)))));
+        }
+
+        return isBlockHeaderToken(t) && !isExpressionContract;
     }
 
     bool isSeparationToken(IdType t) nothrow

--- a/tests/allman/dip1009.d.ref
+++ b/tests/allman/dip1009.d.ref
@@ -1,0 +1,21 @@
+int foo(int arg)
+in
+{
+    assert(arg > 0);
+}
+out (result)
+{
+    assert(result == 0);
+}
+do
+{
+    return 0;
+}
+
+int bar(int arg)
+in(arg > 0)
+out(; true)
+out /*Major*/ ( /*Tom*/ result /*To ground control*/ ; result == 0)
+{
+    return 0;
+}

--- a/tests/dip1009.d
+++ b/tests/dip1009.d
@@ -1,0 +1,15 @@
+int foo(int arg)
+in { assert(arg > 0); }
+out (result) {assert(result == 0);}
+do
+{
+    return 0;
+}
+
+int bar(int arg)
+in ( arg > 0 )
+out(; true)
+out/*Major*/ ( /*Tom*/ result /*To ground control*/; result==0)
+{
+    return 0;
+}

--- a/tests/otbs/dip1009.d.ref
+++ b/tests/otbs/dip1009.d.ref
@@ -1,0 +1,17 @@
+int foo(int arg)
+in {
+    assert(arg > 0);
+}
+out (result) {
+    assert(result == 0);
+}
+do {
+    return 0;
+}
+
+int bar(int arg)
+in(arg > 0)
+out(; true)
+out /*Major*/ ( /*Tom*/ result /*To ground control*/ ; result == 0) {
+    return 0;
+}


### PR DESCRIPTION
I don't know if what I did is a correct way to do it (I've never really touched lexing and such before).
In `isBlockHeaderToken()` I added `in` because just like `out`, it can be a block header with classic contract syntax (maybe that should be in a separate commit ?).
In `isBlockHeader()`, I think changing `i + index >= tokens.length` to `i + index + 1 >= tokens.length` should not be a problem since even if the token is not outside of the range of `tokens`, if it's the very last one it shouldn't be a block header (if it is, then we'd be formatting invalid code anyway).