### PR TITLE
Deprecate enforce ex (#377) for 0.8.x

### DIFF
--- a/src/dfmt/main.d
+++ b/src/dfmt/main.d
@@ -85,9 +85,9 @@ else
         void handleBooleans(string option, string value)
         {
             import dfmt.editorconfig : OptionalBoolean;
-            import std.exception : enforceEx;
+            import std.exception : enforce;
 
-            enforceEx!GetOptException(value == "true" || value == "false", "Invalid argument");
+            enforce!GetOptException(value == "true" || value == "false", "Invalid argument");
             immutable OptionalBoolean optVal = value == "true" ? OptionalBoolean.t
                 : OptionalBoolean.f;
             switch (option)


### PR DESCRIPTION
picked from 0.x.x, sorry i 've get today that neptune propagate from bottom to top instead of the opposite.