### PR TITLE
Properly format enum member attributes and parameter attributes (#375)

### DIFF
--- a/src/dfmt/ast_info.d
+++ b/src/dfmt/ast_info.d
@@ -36,6 +36,7 @@ struct ASTInformation
         sort(spaceAfterLocations);
         sort(unaryLocations);
         sort(attributeDeclarationLines);
+        sort(atAttributeStartLocations);
         sort(caseEndLocations);
         sort(structInitStartLocations);
         sort(structInitEndLocations);
@@ -66,6 +67,9 @@ struct ASTInformation
 
     /// Lines containing attribute declarations
     size_t[] attributeDeclarationLines;
+
+    /// Lines containing attribute declarations that can be followed by a new line
+    size_t[] atAttributeStartLocations;
 
     /// Case statement colon locations
     size_t[] caseEndLocations;
@@ -333,6 +337,34 @@ final class FormatVisitor : ASTVisitor
     {
         astInformation.attributeDeclarationLines ~= attributeDeclaration.line;
         attributeDeclaration.accept(this);
+    }
+
+    override void visit(const FunctionAttribute functionAttribute)
+    {
+        if (functionAttribute.atAttribute !is null)
+            astInformation.atAttributeStartLocations ~= functionAttribute.atAttribute.startLocation;
+        functionAttribute.accept(this);
+    }
+
+    override void visit(const MemberFunctionAttribute memberFunctionAttribute)
+    {
+        if (memberFunctionAttribute.atAttribute !is null)
+            astInformation.atAttributeStartLocations ~= memberFunctionAttribute.atAttribute.startLocation;
+        memberFunctionAttribute.accept(this);
+    }
+
+    override void visit(const Attribute attribute)
+    {
+        if (attribute.atAttribute !is null)
+            astInformation.atAttributeStartLocations ~= attribute.atAttribute.startLocation;
+        attribute.accept(this);
+    }
+
+    override void visit(const StorageClass storageClass)
+    {
+        if (storageClass.atAttribute !is null)
+            astInformation.atAttributeStartLocations ~= storageClass.atAttribute.startLocation;
+        storageClass.accept(this);
     }
 
     override void visit(const InStatement inStatement)

--- a/src/dfmt/formatter.d
+++ b/src/dfmt/formatter.d
@@ -629,6 +629,7 @@ private:
 
     void formatAt()
     {
+        immutable size_t atIndex = tokens[index].index;
         writeToken();
         if (currentIs(tok!"identifier"))
             writeToken();
@@ -637,7 +638,8 @@ private:
             writeParens(false);
             if (tokens[index].type == tok!"{")
                 return;
-            if (index < tokens.length && tokens[index - 1].line < tokens[index].line)
+            if (index < tokens.length && tokens[index - 1].line < tokens[index].line
+                    && astInformation.atAttributeStartLocations.canFindIndex(atIndex))
                 newline();
             else
                 write(" ");

--- a/tests/allman/enum_attribs.d.ref
+++ b/tests/allman/enum_attribs.d.ref
@@ -1,0 +1,6 @@
+enum Foo
+{
+
+    deprecated member0,
+    @UDA(0) member1
+}

--- a/tests/allman/func_param_attrib.d.ref
+++ b/tests/allman/func_param_attrib.d.ref
@@ -1,0 +1,1 @@
+void foo(@UDA(0) @UDA(1) Bar bar);

--- a/tests/allman/lambda_param_attrib.d.ref
+++ b/tests/allman/lambda_param_attrib.d.ref
@@ -1,0 +1,1 @@
+alias fun = (@(0) @(1) int p) => ((@Foo p) { return 0; })(p);

--- a/tests/enum_attribs.d
+++ b/tests/enum_attribs.d
@@ -1,0 +1,7 @@
+enum Foo
+{
+
+    deprecated member0  ,
+    @UDA(0)
+  member1
+}

--- a/tests/func_param_attrib.d
+++ b/tests/func_param_attrib.d
@@ -1,0 +1,2 @@
+void foo(@UDA(0)
+@UDA(1)  Bar bar  );

--- a/tests/lambda_param_attrib.d
+++ b/tests/lambda_param_attrib.d
@@ -1,0 +1,2 @@
+alias fun = (@(0)
+@(1) int p) => ((@Foo p){return 0;})(p);

--- a/tests/otbs/enum_attribs.d.ref
+++ b/tests/otbs/enum_attribs.d.ref
@@ -1,0 +1,5 @@
+enum Foo {
+
+    deprecated member0,
+    @UDA(0) member1
+}

--- a/tests/otbs/func_param_attrib.d.ref
+++ b/tests/otbs/func_param_attrib.d.ref
@@ -1,0 +1,1 @@
+void foo(@UDA(0) @UDA(1) Bar bar);

--- a/tests/otbs/lambda_param_attrib.d.ref
+++ b/tests/otbs/lambda_param_attrib.d.ref
@@ -1,0 +1,1 @@
+alias fun = (@(0) @(1) int p) => ((@Foo p) { return 0; })(p);


### PR DESCRIPTION
With the test cases from #386 (after adding some newlines in there).
This makes dfmt write new lines after attributes only if they are not for enum members or function parameters.