### PR TITLE
fix #244 - Wrong indentation for bool enums

### DIFF
--- a/src/dfmt/formatter.d
+++ b/src/dfmt/formatter.d
@@ -1759,6 +1759,8 @@ const pure @safe @nogc:
         case tok!"stringLiteral":
         case tok!"wstringLiteral":
         case tok!"dstringLiteral":
+        case tok!"true":
+        case tok!"false":
             return true;
         default:
             return false;

--- a/tests/allman/issue0244.d.ref
+++ b/tests/allman/issue0244.d.ref
@@ -1,0 +1,5 @@
+enum Status : bool
+{
+    abort = true,
+    ignore = false
+}

--- a/tests/issue0244.d
+++ b/tests/issue0244.d
@@ -1,0 +1,1 @@
+enum Status : bool { abort = true, ignore = false }

--- a/tests/otbs/issue0244.d.ref
+++ b/tests/otbs/issue0244.d.ref
@@ -1,0 +1,4 @@
+enum Status : bool {
+    abort = true,
+    ignore = false
+}


### PR DESCRIPTION
See line 883  of formatter.d

```d
            // Silly hack to format enums better.
            if ((peekBackIsLiteralOrIdent() || peekBackIsOneOf(true, tok!")",
                    tok!",")) && !peekBackIsSlashSlash())
                newline();   
```

`peekBackIsLiteralOrIdent` didn't include `true` and `false` as literals. The fix was already there but incomplete.