### PR TITLE
Fix #246 - Questionable indentation for multiple `with` statements

### DIFF
--- a/src/dfmt/formatter.d
+++ b/src/dfmt/formatter.d
@@ -207,7 +207,7 @@ private:
         }
         else if (currentIs(tok!"with"))
         {
-            if (indents.length == 0 || indents.top != tok!"switch")
+            if (indents.length == 0 || (indents.top != tok!"switch" && indents.top != tok!"with"))
                 indents.push(tok!"with");
             writeToken();
             write(" ");

--- a/tests/allman/issue0246.d.ref
+++ b/tests/allman/issue0246.d.ref
@@ -1,0 +1,23 @@
+unittest
+{
+    with (Object)
+    {
+        // do something
+    }
+    with (Object) with (Object)
+    {
+        // do something
+    }
+    with (Object) with (Object) with (Object)
+    {
+        // do something
+    }
+
+    with (Object)
+    {
+        with (Object)
+        {
+            // do something
+        }
+    }
+}

--- a/tests/issue0246.d
+++ b/tests/issue0246.d
@@ -1,0 +1,24 @@
+unittest
+{
+    with (Object)
+    {
+        // do something
+    }
+    with (Object) with (Object)
+{
+// do something
+}
+    with (Object) with (Object)
+    with (Object)
+        {
+        // do something
+        }
+
+    with (Object)
+    {
+    with (Object)
+    {
+// do something
+    }
+    }
+}

--- a/tests/otbs/issue0246.d.ref
+++ b/tests/otbs/issue0246.d.ref
@@ -1,0 +1,17 @@
+unittest {
+    with (Object) {
+        // do something
+    }
+    with (Object) with (Object) {
+        // do something
+    }
+    with (Object) with (Object) with (Object) {
+        // do something
+    }
+
+    with (Object) {
+        with (Object) {
+            // do something
+        }
+    }
+}


### PR DESCRIPTION
Just checking whether the current indent is already a `with` token seems to be sufficient.