### PR TITLE
Fix #286 - Weird indentation in else branch after wrapping expression

### DIFF
--- a/src/dfmt/formatter.d
+++ b/src/dfmt/formatter.d
@@ -730,6 +730,7 @@ private:
         else
         {
             writeToken();
+            indents.popWrapIndents();
             linebreakHints = [];
             while (indents.topIs(tok!"enum"))
                 indents.pop();

--- a/src/dfmt/formatter.d
+++ b/src/dfmt/formatter.d
@@ -1314,7 +1314,8 @@ private:
             {
                 if (isWrapToken)
                 {
-                    pushWrapIndent();
+                    if (!indents.topIs(tok!"enum"))
+                        pushWrapIndent();
                     write(" ");
                     writeToken();
                     newline();
@@ -1331,7 +1332,8 @@ private:
             {
                 if (isWrapToken)
                 {
-                    pushWrapIndent();
+                    if (!indents.topIs(tok!"enum"))
+                        pushWrapIndent();
                     newline();
                     writeToken();
                 }

--- a/tests/allman/issue0286.d.ref
+++ b/tests/allman/issue0286.d.ref
@@ -2,14 +2,14 @@ void foo()
 {
     if (true)
         enum vectorizeable = aLongExpressionThatCausesWrapping()
-                && aLongExpressionThatCausesWrapping();
+            && aLongExpressionThatCausesWrapping();
     else
         enum vectorizeable = false;
 
     if (true)
     {
         enum vectorizeable = aLongExpressionThatCausesWrapping()
-                && aLongExpressionThatCausesWrapping();
+            && aLongExpressionThatCausesWrapping();
     }
     else
         enum vectorizeable = false;

--- a/tests/allman/issue0286.d.ref
+++ b/tests/allman/issue0286.d.ref
@@ -1,0 +1,16 @@
+void foo()
+{
+    if (true)
+        enum vectorizeable = aLongExpressionThatCausesWrapping()
+                && aLongExpressionThatCausesWrapping();
+    else
+        enum vectorizeable = false;
+
+    if (true)
+    {
+        enum vectorizeable = aLongExpressionThatCausesWrapping()
+                && aLongExpressionThatCausesWrapping();
+    }
+    else
+        enum vectorizeable = false;
+}

--- a/tests/issue0286.d
+++ b/tests/issue0286.d
@@ -1,0 +1,14 @@
+void foo()
+{
+    if (true)
+    enum vectorizeable = aLongExpressionThatCausesWrapping()
+    && aLongExpressionThatCausesWrapping();
+    else
+    enum vectorizeable = false;
+
+    if (true){
+    enum vectorizeable = aLongExpressionThatCausesWrapping()
+    && aLongExpressionThatCausesWrapping();}
+    else
+    enum vectorizeable = false;
+}

--- a/tests/otbs/issue0286.d.ref
+++ b/tests/otbs/issue0286.d.ref
@@ -1,0 +1,13 @@
+void foo() {
+    if (true)
+        enum vectorizeable = aLongExpressionThatCausesWrapping()
+                && aLongExpressionThatCausesWrapping();
+    else
+        enum vectorizeable = false;
+
+    if (true) {
+        enum vectorizeable = aLongExpressionThatCausesWrapping()
+                && aLongExpressionThatCausesWrapping();
+    } else
+        enum vectorizeable = false;
+}

--- a/tests/otbs/issue0286.d.ref
+++ b/tests/otbs/issue0286.d.ref
@@ -1,13 +1,13 @@
 void foo() {
     if (true)
         enum vectorizeable = aLongExpressionThatCausesWrapping()
-                && aLongExpressionThatCausesWrapping();
+            && aLongExpressionThatCausesWrapping();
     else
         enum vectorizeable = false;
 
     if (true) {
         enum vectorizeable = aLongExpressionThatCausesWrapping()
-                && aLongExpressionThatCausesWrapping();
+            && aLongExpressionThatCausesWrapping();
     } else
         enum vectorizeable = false;
 }


### PR DESCRIPTION
Popping wrap indents after end-of-expression semicolons fixes it.