### PR TITLE
Debug with param

### DIFF
--- a/src/dfmt/formatter.d
+++ b/src/dfmt/formatter.d
@@ -732,13 +732,14 @@ private:
             writeToken();
             indents.popWrapIndents();
             linebreakHints = [];
-            while (indents.topIsOneOf(tok!"enum", tok!"try", tok!"catch", tok!"finally"))
+            while (indents.topIsOneOf(tok!"enum", tok!"try", tok!"catch", tok!"finally", tok!"debug"))
                 indents.pop();
             if (indents.topAre(tok!"static", tok!"else"))
             {
                 indents.pop();
                 indents.pop();
             }
+            indentLevel = indents.indentLevel;
             if (config.dfmt_brace_style == BraceStyle.allman)
             {
                 if (!currentIs(tok!"{"))

--- a/src/dfmt/formatter.d
+++ b/src/dfmt/formatter.d
@@ -207,7 +207,7 @@ private:
         }
         else if (currentIs(tok!"with"))
         {
-            if (indents.length == 0 || (indents.top != tok!"switch" && indents.top != tok!"with"))
+            if (indents.length == 0 || !indents.topIsOneOf(tok!"switch", tok!"with"))
                 indents.push(tok!"with");
             writeToken();
             write(" ");
@@ -1552,7 +1552,7 @@ private:
             else
             {
                 if (indents.topIsTemp() && (peekBackIsOneOf(true, tok!"}",
-                        tok!";") && indents.top != tok!";"))
+                        tok!";") && !indents.topIs(tok!";")))
                     indents.popTempIndents();
                 indentLevel = indents.indentLevel;
             }

--- a/tests/allman/debug_with_param.d.ref
+++ b/tests/allman/debug_with_param.d.ref
@@ -1,0 +1,7 @@
+void main()
+{
+    debug (0)
+        foo();
+    else
+        bar();
+}

--- a/tests/debug_with_param.d
+++ b/tests/debug_with_param.d
@@ -1,0 +1,4 @@
+void main()
+{
+debug(0) foo(); else bar();
+}

--- a/tests/otbs/debug_with_param.d.ref
+++ b/tests/otbs/debug_with_param.d.ref
@@ -1,0 +1,6 @@
+void main() {
+    debug (0)
+        foo();
+    else
+        bar();
+}


### PR DESCRIPTION
Right now, this:
```d
void main()
{
debug(0) foo(); else bar();
}
```
gets formatted to this:
```d
void main()
{
    debug (0)
        foo();
        else
            bar();
}
```
There is also a commit to erase the last usages of `indents.top`, since it's error-prone and I somehow ran into a `RangeError` during some testing (even though it doesn't look like it could happen).