### PR TITLE
 Fix #267 - Indentation with debug inconsistent 

### DIFF
--- a/src/dfmt/formatter.d
+++ b/src/dfmt/formatter.d
@@ -230,8 +230,8 @@ private:
             writeToken();
             write(" ");
         }
-        else if ((isBlockHeader() || currentIs(tok!"version")
-                || currentIs(tok!"debug")) && peekIs(tok!"(", false))
+        else if (((isBlockHeader() || currentIs(tok!"version")) && peekIs(tok!"("))
+                || (currentIs(tok!"debug") && peekIs(tok!"{")))
         {
             if (!assumeSorted(astInformation.constraintLocations).equalRange(current.index).empty)
                 formatConstraint();
@@ -1909,19 +1909,19 @@ const pure @safe @nogc:
         }
     }
 
-    bool isBlockHeaderToken(IdType t)
+    bool isBlockHeaderToken(const IdType t)
     {
         return t == tok!"for" || t == tok!"foreach" || t == tok!"foreach_reverse"
             || t == tok!"while" || t == tok!"if" || t == tok!"in"|| t == tok!"out"
             || t == tok!"do" || t == tok!"catch" || t == tok!"with"
-            || t == tok!"synchronized" || t == tok!"scope";
+            || t == tok!"synchronized" || t == tok!"scope" || t == tok!"debug";
     }
 
     bool isBlockHeader(int i = 0) nothrow
     {
         if (i + index < 0 || i + index >= tokens.length)
             return false;
-        auto t = tokens[i + index].type;
+        const t = tokens[i + index].type;
         bool isExpressionContract;
 
         if (i + index + 3 < tokens.length)

--- a/tests/allman/debug-inside-if.d.ref
+++ b/tests/allman/debug-inside-if.d.ref
@@ -1,0 +1,8 @@
+void main()
+{
+    if (true)
+        debug
+        {
+            foo();
+        }
+}

--- a/tests/allman/issue0267.d.ref
+++ b/tests/allman/issue0267.d.ref
@@ -1,0 +1,19 @@
+void main()
+{
+    debug foo();
+    else bar();
+
+    debug (0)
+        foo();
+    else
+        bar();
+
+    // inlineElse reset check
+
+    debug foo();
+
+    if (true)
+        foo();
+    else
+        bar();
+}

--- a/tests/debug-inside-if.d
+++ b/tests/debug-inside-if.d
@@ -1,0 +1,6 @@
+void main()
+{
+if (true)
+debug
+{foo();}
+}

--- a/tests/issue0267.d
+++ b/tests/issue0267.d
@@ -1,0 +1,12 @@
+void main()
+{
+debug foo(); else bar();
+
+debug (0) foo(); else bar();
+
+// inlineElse reset check
+
+debug foo();
+
+if (true) foo(); else bar();
+}

--- a/tests/otbs/debug-inside-if.d.ref
+++ b/tests/otbs/debug-inside-if.d.ref
@@ -1,0 +1,6 @@
+void main() {
+    if (true)
+        debug {
+            foo();
+        }
+}

--- a/tests/otbs/issue0267.d.ref
+++ b/tests/otbs/issue0267.d.ref
@@ -1,0 +1,18 @@
+void main() {
+    debug foo();
+    else bar();
+
+    debug (0)
+        foo();
+    else
+        bar();
+
+    // inlineElse reset check
+
+    debug foo();
+
+    if (true)
+        foo();
+    else
+        bar();
+}


### PR DESCRIPTION
The additional first commit is aimed at debug blocks inside if statements. As of now, this:
```d
void main()
{
if (true)
debug
{foo();}
}
```
will get formatted as this:
```d
void main()
{
    if (true)
        debug
    {
        foo();
    }
}
```
even though the parens should be attributed to `debug` and not `if`.