### PR TITLE
Fix #287 - Extra space after import in delegate

### DIFF
--- a/src/dfmt/formatter.d
+++ b/src/dfmt/formatter.d
@@ -1433,7 +1433,6 @@ private:
                 && !assumeSorted(astInformation.funLitEndLocations).equalRange(
                     tokens[index].index).empty)
         {
-            write(" ");
             return;
         }
 

--- a/tests/allman/issue0287.d.ref
+++ b/tests/allman/issue0287.d.ref
@@ -1,0 +1,3 @@
+alias foo = typeof({ import std.math; });
+alias bar = typeof({ write("aaa"); });
+alias baz = typeof({  });

--- a/tests/issue0287.d
+++ b/tests/issue0287.d
@@ -1,0 +1,3 @@
+alias foo = typeof({import std.math;});
+alias bar = typeof({write("aaa");});
+alias baz = typeof({});

--- a/tests/otbs/issue0287.d.ref
+++ b/tests/otbs/issue0287.d.ref
@@ -1,0 +1,3 @@
+alias foo = typeof({ import std.math; });
+alias bar = typeof({ write("aaa"); });
+alias baz = typeof({  });


### PR DESCRIPTION
I'm really not sure about this one. I don't know what the `write(" ")` line is supposed to do, but right now it looks like it's doing nothing other than #287.

Has the code changed in ways that made this line obsolete ?