### PR TITLE
Allow comments in selective imports.

### DIFF
--- a/src/dfmt/formatter.d
+++ b/src/dfmt/formatter.d
@@ -523,28 +523,20 @@ private:
                 if (config.dfmt_selective_import_space)
                     write(" ");
                 writeToken();
-                write(" ");
-            }
-            else if (currentIs(tok!","))
-            {
-                // compute length until next ',' or ';'
-                int lengthOfNextChunk;
-                for (size_t i = index + 1; i < tokens.length; i++)
-                {
-                    if (tokens[i].type == tok!"," || tokens[i].type == tok!";")
-                        break;
-                    immutable len = tokens[i].text.length;
-                    lengthOfNextChunk += len;
-                }
-                assert(lengthOfNextChunk > 0);
-                writeToken();
-                if (currentLineLength + 1 + lengthOfNextChunk >= config.dfmt_soft_max_line_length)
-                {
-                    pushWrapIndent(tok!",");
-                    newline();
-                }
-                else
+                if (!currentIs(tok!"comment"))
                     write(" ");
+                pushWrapIndent(tok!",");
+            }
+            else if (currentIs(tok!"comment"))
+            {
+                if (peekBack.line != current.line)
+                {
+                    // The comment appears on its own line, keep it there.
+                    if (!peekBackIs(tok!"comment"))
+                        // Comments are already properly separated.
+                        newline();
+                }
+                formatStep();
             }
             else
                 formatStep();

--- a/src/dfmt/formatter.d
+++ b/src/dfmt/formatter.d
@@ -533,7 +533,7 @@ private:
                 {
                     if (tokens[i].type == tok!"," || tokens[i].type == tok!";")
                         break;
-                    const len = tokenLength(tokens[i]);
+                    immutable len = tokens[i].type == tok!"comment" ? tokens[i].text.length : tokenLength(tokens[i]);
                     assert(len >= 0);
                     lengthOfNextChunk += len;
                 }

--- a/src/dfmt/formatter.d
+++ b/src/dfmt/formatter.d
@@ -533,8 +533,7 @@ private:
                 {
                     if (tokens[i].type == tok!"," || tokens[i].type == tok!";")
                         break;
-                    immutable len = tokens[i].type == tok!"comment" ? tokens[i].text.length : tokenLength(tokens[i]);
-                    assert(len >= 0);
+                    immutable len = tokens[i].text.length;
                     lengthOfNextChunk += len;
                 }
                 assert(lengthOfNextChunk > 0);

--- a/tests/allman/issue0349.d.ref
+++ b/tests/allman/issue0349.d.ref
@@ -1,5 +1,6 @@
+import super_long_import_module_name : withSuperLongSymbolNames, andAlsoLotsOfThem;
 import super_long_import_module_name : withSuperLongSymbolNames,
-    andAlsoLotsOfThem;
+    andAlsoLotsOfThem, lotsAnsLots, andLots, andLotsOfThem, lineExceeds120;
 
 private:
 void foo();

--- a/tests/allman/issue0384.d.ref
+++ b/tests/allman/issue0384.d.ref
@@ -1,0 +1,30 @@
+import std.stdio : readln, /* comment1 */ writeln;
+import std.stdio : readln, // comment2
+    writeln;
+import std.stdio : readln,
+    // comment3
+    writeln;
+import std.stdio : readln,
+    /* comment4 */
+    writeln;
+import std.stdio : readln, readln, readln, readln, readln, readln, readln,
+    readln, readln, readln, readln,
+    // comment5
+    writeln;
+import std.stdio : // comment6
+    readln, readln, readln, readln, readln, readln, // comment7
+    // comment8
+    writeln;
+import std.stdio : /* comment9 */
+    readln, readln, readln, readln, readln, readln, /* comment10 */
+    // comment11
+    writeln;
+import std.stdio : readln, // comment12
+    readln, readln, readln, readln, readln, readln, // comment13
+    // comment14
+    writeln;
+import std.stdio : readln,
+    // comment15
+    readln, readln, readln, readln, readln, readln, // comment16
+    // comment17
+    writeln;

--- a/tests/issue0349.d
+++ b/tests/issue0349.d
@@ -1,4 +1,5 @@
 import super_long_import_module_name : withSuperLongSymbolNames, andAlsoLotsOfThem;
+import super_long_import_module_name : withSuperLongSymbolNames, andAlsoLotsOfThem, lotsAnsLots, andLots, andLotsOfThem, lineExceeds120;
 
 private:
 void foo();

--- a/tests/issue0384.d
+++ b/tests/issue0384.d
@@ -1,0 +1,29 @@
+import std.stdio : readln, /* comment1 */ writeln;
+import std.stdio : readln, // comment2
+                   writeln;
+import std.stdio : readln,
+                   // comment3
+                   writeln;
+import std.stdio : readln,
+                   /* comment4 */
+                   writeln;
+import std.stdio : readln, readln, readln, readln, readln, readln, readln, readln, readln, readln, readln,
+                   // comment5
+                   writeln;
+import std.stdio : // comment6
+                   readln, readln, readln, readln, readln, readln, // comment7
+                   // comment8
+                   writeln;
+import std.stdio : /* comment9 */
+                   readln, readln, readln, readln, readln, readln, /* comment10 */
+                   // comment11
+                   writeln;
+import std.stdio : readln, // comment12
+                   readln, readln, readln, readln, readln, readln, // comment13
+                   // comment14
+                   writeln;
+import std.stdio : readln,
+                   // comment15
+                   readln, readln, readln, readln, readln, readln, // comment16
+                   // comment17
+                   writeln;

--- a/tests/otbs/issue0349.d.ref
+++ b/tests/otbs/issue0349.d.ref
@@ -1,5 +1,6 @@
+import super_long_import_module_name : withSuperLongSymbolNames, andAlsoLotsOfThem;
 import super_long_import_module_name : withSuperLongSymbolNames,
-    andAlsoLotsOfThem;
+    andAlsoLotsOfThem, lotsAnsLots, andLots, andLotsOfThem, lineExceeds120;
 
 private:
 void foo();

--- a/tests/otbs/issue0384.d.ref
+++ b/tests/otbs/issue0384.d.ref
@@ -1,0 +1,30 @@
+import std.stdio : readln, /* comment1 */ writeln;
+import std.stdio : readln, // comment2
+    writeln;
+import std.stdio : readln,
+    // comment3
+    writeln;
+import std.stdio : readln,
+    /* comment4 */
+    writeln;
+import std.stdio : readln, readln, readln, readln, readln, readln, readln,
+    readln, readln, readln, readln,
+    // comment5
+    writeln;
+import std.stdio : // comment6
+    readln, readln, readln, readln, readln, readln, // comment7
+    // comment8
+    writeln;
+import std.stdio : /* comment9 */
+    readln, readln, readln, readln, readln, readln, /* comment10 */
+    // comment11
+    writeln;
+import std.stdio : readln, // comment12
+    readln, readln, readln, readln, readln, readln, // comment13
+    // comment14
+    writeln;
+import std.stdio : readln,
+    // comment15
+    readln, readln, readln, readln, readln, readln, // comment16
+    // comment17
+    writeln;


### PR DESCRIPTION
tokenLength() does not consider comments as valid tokens, so get their length explicitly.

Fixes issue 384, allowing comments inbetween the symbols of selective imports.