### PR TITLE
Spaces inside empty braces

### DIFF
--- a/src/dfmt/formatter.d
+++ b/src/dfmt/formatter.d
@@ -805,7 +805,8 @@ private:
             else
             {
                 niBraceDepth++;
-                write(" ");
+                if (!currentIs(tok!"}"))
+                    write(" ");
             }
         }
         else
@@ -872,7 +873,7 @@ private:
         {
             if (niBraceDepth > 0)
             {
-                if (!peekBackIsSlashSlash())
+                if (!peekBackIsSlashSlash() && !peekBackIs(tok!"{"))
                     write(" ");
                 niBraceDepth--;
             }

--- a/tests/allman/issue0119.d.ref
+++ b/tests/allman/issue0119.d.ref
@@ -1,5 +1,5 @@
-auto fun = function() {  };
-auto fun = () {  };
+auto fun = function() {};
+auto fun = () {};
 auto fun = {};
 
 auto fun = { int i; };

--- a/tests/allman/issue0287.d.ref
+++ b/tests/allman/issue0287.d.ref
@@ -1,3 +1,3 @@
 alias foo = typeof({ import std.math; });
 alias bar = typeof({ write("aaa"); });
-alias baz = typeof({  });
+alias baz = typeof({});

--- a/tests/otbs/issue0119.d.ref
+++ b/tests/otbs/issue0119.d.ref
@@ -1,5 +1,5 @@
-auto fun = function() {  };
-auto fun = () {  };
+auto fun = function() {};
+auto fun = () {};
 auto fun = {};
 
 auto fun = { int i; };

--- a/tests/otbs/issue0287.d.ref
+++ b/tests/otbs/issue0287.d.ref
@@ -1,3 +1,3 @@
 alias foo = typeof({ import std.math; });
 alias bar = typeof({ write("aaa"); });
-alias baz = typeof({  });
+alias baz = typeof({});


### PR DESCRIPTION
I guess this is really subjective, but I've noticed that empty braces always have 2 spaces between them.
It makes sense to put spaces when there is something in between, but when the braces are empty, it looks a bit awkward.
In [this test file](https://github.com/dlang-community/dfmt/blob/master/tests/allman/issue0287.d.ref) for example, `typeof({});` gets formatted as `typeof({  });` (with an extra space that Github won't render for some reason), which looks weird (to me).

Again, I know that this is very much about personal taste; but I do think that having two spaces is too much. Even if completely empty braces are a no-go, having a single space instead of two should be sufficient.