### PR TITLE
Fix #407 - `dub run dfmt` keeps building dfmt anew each time

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -15,6 +15,6 @@
         "built_with_dub"
     ],
     "preGenerateCommands" : [
-      "rdmd --eval=\"auto dir=environment.get(\\\"DUB_PACKAGE_DIR\\\"); dir.buildPath(\\\"bin\\\").mkdirRecurse; auto gitVer = (\\\"git -C \\\"~dir~\\\" describe --tags\\\").executeShell; (gitVer.status == 0 ? gitVer.output.strip : \\\"v\\\" ~ dir.dirName.baseName.findSplitAfter(environment.get(\\\"DUB_ROOT_PACKAGE\\\")~\\\"-\\\")[1]).ifThrown(\\\"0.0.0\\\").chain(newline).to!string.toFile(dir.buildPath(\\\"bin\\\", \\\"dubhash.txt\\\"));\""
+      "rdmd dubhash.d"
     ]
 }

--- a/dubhash.d
+++ b/dubhash.d
@@ -1,0 +1,23 @@
+import std.algorithm;
+import std.ascii;
+import std.conv;
+import std.exception;
+import std.file;
+import std.path;
+import std.process;
+import std.range;
+import std.string;
+
+void main()
+{
+    auto dir = environment.get("DUB_PACKAGE_DIR");
+    auto hashFile = dir.buildPath("bin", "dubhash.txt");
+    auto gitVer = executeShell("git -C " ~ dir ~ " describe --tags");
+    auto ver = (gitVer.status == 0 ? gitVer.output.strip
+            : "v" ~ dir.dirName.baseName.findSplitAfter(
+                environment.get("DUB_ROOT_PACKAGE") ~ "-")[1]).ifThrown("0.0.0")
+        .chain(newline).to!string.strip;
+    dir.buildPath("bin").mkdirRecurse;
+    if (!hashFile.exists || ver != hashFile.readText.strip)
+        hashFile.write(ver);
+}


### PR DESCRIPTION
The reason dub rebuilds dfmt all the time is because `dubhash.txt` gets modified with the `preGenerateCommand`. By making this command only re-write `dubhash.txt` when the hash actually changed, then dfmt will not be rebuilt if no change has occured.

Also, I couldn't stand this huge single line in `dub.json` so I moved it in its own file instead of making it even bigger.