### PR TITLE
fix dub dependency build (fix #413)

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -15,6 +15,6 @@
         "built_with_dub"
     ],
     "preGenerateCommands" : [
-      "rdmd dubhash.d"
+      "rdmd $PACKAGE_DIR/dubhash.d"
     ]
 }


### PR DESCRIPTION
run rdmd with `$PACKAGE_DIR` dub variable for an absolute path. The dubhash.d already uses the environment variable set by dub which tells it where the package is