### PR TITLE
Associative array formatting & space_before_aa_colon option

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ found in .editorconfig files.
 * **--selective_import_space**: See **dfmt_selective_import_space** below
 * **--compact_labeled_statements**: See **dfmt_compact_labeled_statements** below
 * **--template_constraint_style**: See **dfmt_template_constraint_style** below
+* **--space_before_aa_colon**: See **dfmt_space_before_aa_colon** below
 
 ### Example
 ```
@@ -107,6 +108,7 @@ dfmt_selective_import_space | `true`, `false` | `true` | Insert space after the 
 dfmt_compact_labeled_statements | `true`, `false` | `true` | Place labels on the same line as the labeled `switch`, `for`, `foreach`, or `while` statement.
 dfmt_template_constraint_style | `conditional_newline_indent` `conditional_newline` `always_newline` `always_newline_indent` | `conditional_newline_indent` | Control the formatting of template constraints.
 dfmt_single_template_constraint_indent | `true`, `false` | `false` | Set if the constraints are indented by a single tab instead of two. Has only an effect for if indentation style if set to `always_newline_indent` or `conditional_newline_indent`.
+dfmt_space_before_aa_colon | `true`, `false` | `false` | Adds a space after an associative array key before the `:` like in older dfmt versions.
 
 ## Terminology
 * Braces - `{` and `}`

--- a/src/dfmt/ast_info.d
+++ b/src/dfmt/ast_info.d
@@ -45,6 +45,7 @@ struct ASTInformation
         sort(conditionalWithElseLocations);
         sort(conditionalStatementLocations);
         sort(arrayStartLocations);
+        sort(assocArrayStartLocations);
         sort(contractLocations);
         sort(constraintLocations);
         sort(constructorDestructorLocations);
@@ -95,6 +96,9 @@ struct ASTInformation
     /// Locations of start locations of array initializers
     size_t[] arrayStartLocations;
 
+    /// Locations of start locations of associative array initializers
+    size_t[] assocArrayStartLocations;
+
     /// Locations of "in" and "out" tokens that begin contracts
     size_t[] contractLocations;
 
@@ -134,6 +138,19 @@ final class FormatVisitor : ASTVisitor
     {
         astInformation.arrayStartLocations ~= arrayInitializer.startLocation;
         arrayInitializer.accept(this);
+    }
+
+    override void visit(const ArrayLiteral arrayLiteral)
+    {
+        astInformation.arrayStartLocations ~= arrayLiteral.tokens[0].index;
+        arrayLiteral.accept(this);
+    }
+
+    override void visit(const AssocArrayLiteral assocArrayLiteral)
+    {
+        astInformation.arrayStartLocations ~= assocArrayLiteral.tokens[0].index;
+        astInformation.assocArrayStartLocations ~= assocArrayLiteral.tokens[0].index;
+        assocArrayLiteral.accept(this);
     }
 
     override void visit (const SharedStaticConstructor sharedStaticConstructor)

--- a/src/dfmt/config.d
+++ b/src/dfmt/config.d
@@ -55,6 +55,8 @@ struct Config
     TemplateConstraintStyle dfmt_template_constraint_style;
     ///
     OptionalBoolean dfmt_single_template_constraint_indent;
+    ///
+    OptionalBoolean dfmt_space_before_aa_colon;
 
     mixin StandardEditorConfigFields;
 
@@ -82,6 +84,7 @@ struct Config
         dfmt_compact_labeled_statements = OptionalBoolean.t;
         dfmt_template_constraint_style = TemplateConstraintStyle.conditional_newline_indent;
         dfmt_single_template_constraint_indent = OptionalBoolean.f;
+        dfmt_space_before_aa_colon = OptionalBoolean.f;
     }
 
     /**

--- a/src/dfmt/formatter.d
+++ b/src/dfmt/formatter.d
@@ -571,7 +571,7 @@ private:
             return;
         immutable bool arrayInitializerStart = p == tok!"["
             && astInformation.arrayStartLocations.canFindIndex(tokens[index - 1].index);
-        if (arrayInitializerStart && isMultilineAt(index))
+        if (arrayInitializerStart && isMultilineAt(index - 1))
         {
             // Use the close bracket as the indent token to distinguish
             // the array initialiazer from an array index in the newline
@@ -642,6 +642,26 @@ private:
         }
         else
             writeToken();
+    }
+
+    void formatRightBracket()
+    in
+    {
+        assert(currentIs(tok!"]"));
+    }
+    body
+    {
+        indents.popWrapIndents();
+        if (indents.topIs(tok!"]"))
+        {
+            if (!indents.topDetails.mini)
+                newline();
+            else
+                indents.pop();
+        }
+        writeToken();
+        if (currentIs(tok!"identifier"))
+            write(" ");
     }
 
     void formatAt()
@@ -1258,17 +1278,7 @@ private:
             formatColon();
             break;
         case tok!"]":
-            indents.popWrapIndents();
-            if (indents.topIs(tok!"]"))
-            {
-                if (!indents.topDetails.mini)
-                    newline();
-                else
-                    indents.pop();
-            }
-            writeToken();
-            if (currentIs(tok!"identifier"))
-                write(" ");
+            formatRightBracket();
             break;
         case tok!";":
             formatSemicolon();

--- a/src/dfmt/main.d
+++ b/src/dfmt/main.d
@@ -89,6 +89,9 @@ else
             case "single_template_constraint_indent":
                 optConfig.dfmt_single_template_constraint_indent = optVal;
                 break;
+            case "space_before_aa_colon":
+                optConfig.dfmt_space_before_aa_colon = optVal;
+                break;
             default:
                 assert(false, "Invalid command-line switch");
             }
@@ -116,6 +119,7 @@ else
                 "split_operator_at_line_end", &handleBooleans,
                 "compact_labeled_statements", &handleBooleans,
                 "single_template_constraint_indent", &handleBooleans,
+                "space_before_aa_colon", &handleBooleans,
                 "tab_width", &optConfig.tab_width,
                 "template_constraint_style", &optConfig.dfmt_template_constraint_style);
             // dfmt on
@@ -314,6 +318,7 @@ Formatting Options:
     --split_operator_at_line_end
     --compact_labeled_statements
     --template_constraint_style
+    --space_before_aa_colon
         `,
             optionsToString!(typeof(Config.dfmt_template_constraint_style)));
 }

--- a/src/dfmt/tokens.d
+++ b/src/dfmt/tokens.d
@@ -184,6 +184,8 @@ int breakCost(IdType p, IdType c) pure nothrow @safe @nogc
     case tok!"+=":
         return 200;
     case tok!":":
+        // colon could be after a label or an import, where it should normally wrap like before
+        // for everything else (associative arrays) try not breaking around colons
         return p == tok!"identifier" ? 0 : 300;
     case tok!".":
         return p == tok!")" ? 0 : 300;

--- a/src/dfmt/tokens.d
+++ b/src/dfmt/tokens.d
@@ -134,7 +134,6 @@ int breakCost(IdType p, IdType c) pure nothrow @safe @nogc
     case tok!"||":
     case tok!"&&":
     case tok!",":
-    case tok!":":
     case tok!"?":
         return 0;
     case tok!"(":
@@ -184,6 +183,8 @@ int breakCost(IdType p, IdType c) pure nothrow @safe @nogc
     case tok!"~":
     case tok!"+=":
         return 200;
+    case tok!":":
+        return p == tok!"identifier" ? 0 : 300;
     case tok!".":
         return p == tok!")" ? 0 : 300;
     default:

--- a/tests/allman/associative_array.d.ref
+++ b/tests/allman/associative_array.d.ref
@@ -1,0 +1,26 @@
+unittest
+{
+    Bson base = Bson([
+            "maps": Bson([
+                Bson(["id": Bson(4), "comment": Bson("hello")]),
+                Bson(["id": Bson(49), "comment": Bson(null)])
+            ]),
+            "short": Bson(["a": "b", "c": "d"]),
+            "numbers": Bson([
+                1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0,
+                1, 2, 3, 4, 5, 6, 7, 8, 9, 0
+            ]),
+            "shuffleOnReset": serializeToBson([
+                "all": false,
+                "selected": true,
+                "maybe": false
+            ]),
+            "resetOnEmpty": Bson(false),
+            "applyMods": Bson(true),
+            "sendComments": Bson(true)
+            ]);
+    int[] x = [
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3,
+        4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0
+    ];
+}

--- a/tests/allman/issue0017.d.ref
+++ b/tests/allman/issue0017.d.ref
@@ -1,3 +1,4 @@
-immutable NameId[] namesA = [{"Aacgr", 0x00386}, // GREEK CAPITAL LETTER ALPHA WITH TONOS
+immutable NameId[] namesA = [
+{"Aacgr", 0x00386}, // GREEK CAPITAL LETTER ALPHA WITH TONOS
 {"aacgr", 0x003AC}, // GREEK SMALL LETTER ALPHA WITH TONOS
 ];

--- a/tests/associative_array.d
+++ b/tests/associative_array.d
@@ -1,0 +1,26 @@
+unittest
+{
+	Bson base = Bson([
+		"maps": Bson([
+			Bson([
+				"id": Bson(4),
+				"comment": Bson("hello")
+			]),
+			Bson([
+				"id": Bson(49),
+				"comment": Bson(null)
+			])
+		]),
+		"short": Bson(["a": "b", "c": "d"]),
+		"numbers": Bson([1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0]),
+		"shuffleOnReset": serializeToBson([
+			"all": false,
+			"selected": true,
+			"maybe": false
+		]),
+		"resetOnEmpty": Bson(false),
+		"applyMods": Bson(true),
+		"sendComments": Bson(true)
+	]);
+	int[] x = [1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0];
+}

--- a/tests/issue0128.args
+++ b/tests/issue0128.args
@@ -1,0 +1,1 @@
+--space_before_aa_colon=true

--- a/tests/otbs/associative_array.d.ref
+++ b/tests/otbs/associative_array.d.ref
@@ -1,0 +1,25 @@
+unittest {
+    Bson base = Bson([
+            "maps": Bson([
+                Bson(["id": Bson(4), "comment": Bson("hello")]),
+                Bson(["id": Bson(49), "comment": Bson(null)])
+            ]),
+            "short": Bson(["a": "b", "c": "d"]),
+            "numbers": Bson([
+                1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0,
+                1, 2, 3, 4, 5, 6, 7, 8, 9, 0
+            ]),
+            "shuffleOnReset": serializeToBson([
+                "all": false,
+                "selected": true,
+                "maybe": false
+            ]),
+            "resetOnEmpty": Bson(false),
+            "applyMods": Bson(true),
+            "sendComments": Bson(true)
+            ]);
+    int[] x = [
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3,
+        4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0
+    ];
+}

--- a/tests/otbs/issue0017.d.ref
+++ b/tests/otbs/issue0017.d.ref
@@ -1,3 +1,4 @@
-immutable NameId[] namesA = [{"Aacgr", 0x00386}, // GREEK CAPITAL LETTER ALPHA WITH TONOS
+immutable NameId[] namesA = [
+{"Aacgr", 0x00386}, // GREEK CAPITAL LETTER ALPHA WITH TONOS
 {"aacgr", 0x003AC}, // GREEK SMALL LETTER ALPHA WITH TONOS
 ];


### PR DESCRIPTION
Fixes #143, partially even implements #312

I have improved the formatting of AA literals, which now (when they extend over the maximum line length) span every key into their own line but otherwise try to stay compact.

Normal arrays now also use this logic 

For example for this input code:
```d
	Bson base = Bson([
		"maps": Bson([
			Bson([
				"id": Bson(4),
				"comment": Bson("hello")
			]),
			Bson([
				"id": Bson(49),
				"comment": Bson(null)
			])
		]),
		"short": Bson(["a": "b", "c": "d"]),
		"numbers": Bson([1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0]),
		"shuffleOnReset": serializeToBson([
			"all": false,
			"selected": true,
			"maybe": false
		]),
		"resetOnEmpty": Bson(false),
		"applyMods": Bson(true),
		"sendComments": Bson(true)
	]);
```

dfmt previously emitted:
```d
    Bson base = Bson(["maps" : Bson([Bson(["id" : Bson(4), "comment"
            : Bson("hello")]), Bson(["id" : Bson(49), "comment" : Bson(null)])]),
            "short" : Bson(["a" : "b"]), "numbers" : Bson([1, 2, 3, 4, 5, 6, 7,
                8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0]),
            "shuffleOnReset" : serializeToBson(["all" : false,
                "selected" : true, "maybe" : false]), "resetOnEmpty" : Bson(false),
            "applyMods" : Bson(true), "sendComments" : Bson(true)]);
```

and after the PR it emits:
```d
    Bson base = Bson([
            "maps": Bson([
                Bson(["id": Bson(4), "comment": Bson("hello")]),
                Bson(["id": Bson(49), "comment": Bson(null)])
            ]),
            "short": Bson(["a": "b", "c": "d"]),
            "numbers": Bson([
                1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0,
                1, 2, 3, 4, 5, 6, 7, 8, 9, 0
            ]),
            "shuffleOnReset": serializeToBson([
                "all": false,
                "selected": true,
                "maybe": false
            ]),
            "resetOnEmpty": Bson(false),
            "applyMods": Bson(true),
            "sendComments": Bson(true)
            ]);
```

I split the PR into 5 commits which each do a very specific upgrade I had to do to make this work. I added extra information into the indentation stack which can be used to more finely tune the indentation settings (as in this case `]` either being array end or AA end)

I think checking for long line in the array is also better than previously having suggested line wraps and wrapping there. Though old behavior doesn't change (as all tests still pass)