### PR TITLE
fix array item access regression

### DIFF
--- a/src/dfmt/formatter.d
+++ b/src/dfmt/formatter.d
@@ -611,6 +611,15 @@ private:
 
             indents.push(tok!"]", detail);
         }
+        else if (p == tok!"[")
+        {
+            // array item access
+            IndentStack.Details detail;
+            detail.wrap = false;
+            detail.temp = true;
+            detail.mini = true;
+            indents.push(tok!"]", detail);
+        }
         else if (!currentIs(tok!")") && !currentIs(tok!"]")
                 && (linebreakHints.canFindIndex(index - 1) || (linebreakHints.length == 0
                     && currentLineLength > config.max_line_length)))
@@ -664,7 +673,7 @@ private:
         indents.popWrapIndents();
         if (indents.topIs(tok!"]"))
         {
-            if (!indents.topDetails.mini)
+            if (!indents.topDetails.mini && !indents.topDetails.temp)
                 newline();
             else
                 indents.pop();
@@ -839,6 +848,8 @@ private:
         }
         else if (astInformation.funLitStartLocations.canFindIndex(tIndex))
         {
+            indents.popWrapIndents();
+
             sBraceDepth++;
             if (peekBackIsOneOf(true, tok!")", tok!"identifier"))
                 write(" ");

--- a/tests/allman/array_access.d.ref
+++ b/tests/allman/array_access.d.ref
@@ -1,0 +1,7 @@
+unittest
+{
+    foo([
+            target.value.region[1], target.value.region[1],
+            target.value.region[1], target.value.region[1], target.value.region[1]
+            ]);
+}

--- a/tests/allman/issue0112_variation.d.ref
+++ b/tests/allman/issue0112_variation.d.ref
@@ -1,0 +1,15 @@
+unittest
+{
+    testScene = new Scene(longArgument, longArgument, longArgument,
+            longArgument, longArgument, longArgument, delegate(Scene scene) {
+        import std.stdio;
+
+        if (!scene.alreadyEntered)
+        {
+            fwriteln(
+                "This is a test. This is a test. This is a test. This is a test. This is a test. Test12.");
+            auto p = cast(Portal) sceneManager.previousScene;
+            scene.destroyCurrentScript();
+        }
+    });
+}

--- a/tests/array_access.d
+++ b/tests/array_access.d
@@ -1,0 +1,4 @@
+unittest
+{
+	foo([target.value.region[1], target.value.region[1], target.value.region[1], target.value.region[1], target.value.region[1]]);
+}

--- a/tests/issue0112_variation.d
+++ b/tests/issue0112_variation.d
@@ -1,0 +1,18 @@
+unittest
+{
+	testScene = new Scene
+	(
+		longArgument, longArgument, longArgument, longArgument, longArgument, longArgument,
+		 delegate(Scene scene)
+		 {
+			 import std.stdio;
+
+			 if (!scene.alreadyEntered)
+			 {
+				 fwriteln("This is a test. This is a test. This is a test. This is a test. This is a test. Test12.");
+				 auto p = cast(Portal)sceneManager.previousScene;
+				 scene.destroyCurrentScript();
+			 }
+		 }
+	);
+}

--- a/tests/otbs/array_access.d.ref
+++ b/tests/otbs/array_access.d.ref
@@ -1,0 +1,6 @@
+unittest {
+    foo([
+            target.value.region[1], target.value.region[1],
+            target.value.region[1], target.value.region[1], target.value.region[1]
+            ]);
+}

--- a/tests/otbs/issue0112_variation.d.ref
+++ b/tests/otbs/issue0112_variation.d.ref
@@ -1,0 +1,13 @@
+unittest {
+    testScene = new Scene(longArgument, longArgument, longArgument,
+            longArgument, longArgument, longArgument, delegate(Scene scene) {
+        import std.stdio;
+
+        if (!scene.alreadyEntered) {
+            fwriteln(
+                "This is a test. This is a test. This is a test. This is a test. This is a test. Test12.");
+            auto p = cast(Portal) sceneManager.previousScene;
+            scene.destroyCurrentScript();
+        }
+    });
+}


### PR DESCRIPTION
This PR makes sure array item indices are properly formatted. Before the `]` would insert a new line for array item access for a value inside a large array:
```d
    foo([
            target.value.region[1
            ], target.value.region[1],
            target.value.region[1], target.value.region[1], target.value.region[1]]);
```

now:
```d
    foo([
            target.value.region[1], target.value.region[1],
            target.value.region[1], target.value.region[1], target.value.region[1]
            ]);
```

still the indentation is a little bit too much for my taste, but I think that can be done in a separate PR in the future