### PR TITLE
Fix dubhash with spaces in folder name

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -15,6 +15,6 @@
         "built_with_dub"
     ],
     "preGenerateCommands" : [
-      "rdmd $PACKAGE_DIR/dubhash.d"
+      "rdmd \"$PACKAGE_DIR/dubhash.d\""
     ]
 }


### PR DESCRIPTION
This fixes an issue with spaces in the filename as seen in https://github.com/Pure-D/serve-d/issues/53#issuecomment-454130081

`rdmd $PACKAGE_DIR/dubhash.d` would evaluate to `["rdmd", "C:/Users/Foo", "Bar/source/dfmt/dubhash.d"]` which would make rdmd think the first argument is something to compile too