### PR TITLE
Fix #427 - Crash on invariant

### DIFF
--- a/src/dfmt/ast_info.d
+++ b/src/dfmt/ast_info.d
@@ -292,7 +292,9 @@ final class FormatVisitor : ASTVisitor
 
     override void visit(const Invariant invariant_)
     {
-        astInformation.doubleNewlineLocations ~= invariant_.blockStatement.endLocation;
+        if (invariant_.blockStatement !is null)
+            astInformation.doubleNewlineLocations ~= invariant_.blockStatement.endLocation;
+        
         invariant_.accept(this);
     }
 


### PR DESCRIPTION
With upgrading to libdparse v0.10.x, I didn't take into account the fact that invariants don't always have bodies anymore.