### PR TITLE
Update libdparse to v0.11.2

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -4,7 +4,7 @@
     "targetType": "autodetect",
     "license": "BSL-1.0",
     "dependencies": {
-      "libdparse": "~>0.10.12"
+      "libdparse": "~>0.11.2"
     },
     "targetPath" : "bin/",
     "targetName" : "dfmt",

--- a/src/dfmt/tokens.d
+++ b/src/dfmt/tokens.d
@@ -230,7 +230,7 @@ private string generateFixedLengthCases()
         "package", "pragma", "private", "protected", "public", "pure", "real", "ref", "return", "scope",
         "shared", "short", "static", "struct", "super", "switch", "synchronized", "template", "this",
         "throw", "true", "try", "typedef", "typeid", "typeof", "ubyte", "ucent", "uint", "ulong",
-        "union", "unittest", "ushort", "version", "void", "volatile", "wchar",
+        "union", "unittest", "ushort", "version", "void", "wchar",
         "while", "with", "__DATE__", "__EOF__", "__FILE__",
         "__FUNCTION__", "__gshared", "__LINE__", "__MODULE__", "__parameters",
         "__PRETTY_FUNCTION__", "__TIME__", "__TIMESTAMP__",


### PR DESCRIPTION
With the removal of the `volatile` keyword