### PR TITLE
upgrade libdparse to 0.13.z

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -4,7 +4,7 @@
     "targetType": "autodetect",
     "license": "BSL-1.0",
     "dependencies": {
-      "libdparse": "~>0.11.4"
+      "libdparse": "~>0.13.0"
     },
     "targetPath" : "bin/",
     "targetName" : "dfmt",


### PR DESCRIPTION
this was trivially working already. Makes this dfmt version compatible with latest D-Scanner

(dub dependency is >=0.13.0 to allow more future versions, submodule is 0.13.1)