### PR TITLE
Put space between a comment and an identifier

### DIFF
--- a/src/dfmt/formatter.d
+++ b/src/dfmt/formatter.d
@@ -448,7 +448,7 @@ private:
                 write(" ");
             else if (prevTokenEndLine == currTokenLine || (t == tok!")" && peekIs(tok!"{")))
                 write(" ");
-            else if (t == tok!"else")
+            else if (peekBackIsOneOf(false, tok!"else", tok!"identifier"))
                 write(" ");
             else if (canAddNewline || (peekIs(tok!"{") && t == tok!"}"))
                 newline();

--- a/tests/allman/issue0452.d.ref
+++ b/tests/allman/issue0452.d.ref
@@ -1,0 +1,2 @@
+@nogc //
+void foo();

--- a/tests/issue0452.d
+++ b/tests/issue0452.d
@@ -1,0 +1,3 @@
+@nogc
+//
+void foo();

--- a/tests/otbs/issue0452.d.ref
+++ b/tests/otbs/issue0452.d.ref
@@ -1,0 +1,2 @@
+@nogc //
+void foo();


### PR DESCRIPTION
Actual formatting:

```diff
-@nogc
-//
+@nogc//
 void foo();
```