### PR TITLE
Put a space in contract expressions

### DIFF
--- a/src/dfmt/formatter.d
+++ b/src/dfmt/formatter.d
@@ -1135,7 +1135,7 @@ private:
             else if (peekBackIsKeyword)
                 write(" ");
             writeToken();
-            if (!currentIs(tok!"(") && !currentIs(tok!"{") && !currentIs(tok!"comment"))
+            if (!currentIs(tok!"{") && !currentIs(tok!"comment"))
                 write(" ");
             break;
         case tok!"try":
@@ -1169,7 +1169,7 @@ private:
                     current.index);
             if (isFunctionLit && config.dfmt_brace_style == BraceStyle.allman)
                 newline();
-            else if (!isContract)
+            else if (!isContract || currentIs(tok!"("))
                 write(" ");
             break;
         case tok!"is":
@@ -1218,6 +1218,11 @@ private:
                 }
             }
             goto default;
+        case tok!"invariant":
+            writeToken();
+            if (currentIs(tok!"("))
+                write(" ");
+            break;
         default:
             if (peekBackIs(tok!"identifier"))
                 write(" ");

--- a/tests/allman/dip1009.d.ref
+++ b/tests/allman/dip1009.d.ref
@@ -13,8 +13,8 @@ do
 }
 
 int bar(int arg)
-in(arg > 0)
-out(; true)
+in (arg > 0)
+out (; true)
 out /*Major*/ ( /*Tom*/ result /*To ground control*/ ; result == 0)
 {
     return 0;

--- a/tests/allman/issue0448.d.ref
+++ b/tests/allman/issue0448.d.ref
@@ -1,0 +1,4 @@
+struct S
+{
+    invariant (true);
+}

--- a/tests/issue0448.d
+++ b/tests/issue0448.d
@@ -1,0 +1,4 @@
+struct S
+{
+    invariant(true);
+}

--- a/tests/otbs/dip1009.d.ref
+++ b/tests/otbs/dip1009.d.ref
@@ -10,8 +10,8 @@ do {
 }
 
 int bar(int arg)
-in(arg > 0)
-out(; true)
+in (arg > 0)
+out (; true)
 out /*Major*/ ( /*Tom*/ result /*To ground control*/ ; result == 0) {
     return 0;
 }

--- a/tests/otbs/issue0448.d.ref
+++ b/tests/otbs/issue0448.d.ref
@@ -1,0 +1,3 @@
+struct S {
+    invariant (true);
+}


### PR DESCRIPTION
Fixes #448.

Puts a space between `in`, `out`, `invariant` and `(`, consistent with `if (`.