### PR TITLE
Wrap the argument list of a template function

### DIFF
--- a/src/dfmt/formatter.d
+++ b/src/dfmt/formatter.d
@@ -452,6 +452,9 @@ private:
                 write(" ");
             else if (canAddNewline || (peekIs(tok!"{") && t == tok!"}"))
                 newline();
+
+            if (peekIs(tok!"(") && (peekBackIs(tok!")") || peekBack2Is(tok!"!")))
+                pushWrapIndent(tok!"(");
         }
         writeToken();
         immutable j = justAddedExtraNewline;

--- a/tests/allman/issue0454.d.ref
+++ b/tests/allman/issue0454.d.ref
@@ -1,0 +1,10 @@
+void main()
+{
+    format!"%s" //
+            ("");
+    format!("%s") //
+            ("");
+    format!("%s") //
+            ("", argument1, argument2, argument3, argument4, argument5,
+            argument6, argument7, argument8, argument9, argument10);
+}

--- a/tests/issue0454.d
+++ b/tests/issue0454.d
@@ -1,0 +1,9 @@
+void main()
+{
+    format!"%s" //
+        ("");
+    format!("%s") //
+        ("");
+    format!("%s") //
+        ("", argument1, argument2, argument3, argument4, argument5, argument6, argument7, argument8, argument9, argument10);
+}

--- a/tests/otbs/issue0454.d.ref
+++ b/tests/otbs/issue0454.d.ref
@@ -1,0 +1,9 @@
+void main() {
+    format!"%s" //
+            ("");
+    format!("%s") //
+            ("");
+    format!("%s") //
+            ("", argument1, argument2, argument3, argument4, argument5,
+            argument6, argument7, argument8, argument9, argument10);
+}


### PR DESCRIPTION
Fixes #454.

```diff
 void main()
 {
     import std.format;

     format!"was auch immer %s" //
-        ("string");
+    ("string");
 }
```