### PR TITLE
Support disabling automatic line breaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ found there.
 * `--split_operator_at_line_end`: *see dfmt_split_operator_at_line_end [below](#dfmt-specific-properties)*
 * `--tab_width`: *see tab_width [below](#standard-editorconfig-properties)*
 * `--template_constraint_style`: *see dfmt_template_constraint_style [below](#dfmt-specific-properties)*
+* `--keep_line_breaks`: *see dfmt_keep_line_breaks [below](#dfmt-specific-properties)*
 
 ### Example
 ```
@@ -114,6 +115,7 @@ dfmt_compact_labeled_statements | **`true`**, `false` | Place labels on the same
 dfmt_template_constraint_style | **`conditional_newline_indent`** `conditional_newline` `always_newline` `always_newline_indent` | Control the formatting of template constraints.
 dfmt_single_template_constraint_indent | `true`, **`false`** | Set if the constraints are indented by a single tab instead of two. Has only an effect if the style set to `always_newline_indent` or `conditional_newline_indent`.
 dfmt_space_before_aa_colon | `true`, **`false`** | Adds a space after an associative array key before the `:` like in older dfmt versions.
+dfmt_keep_line_breaks | `true`, **`false`** | Keep existing line breaks if these don't violate other formatting rules.
 
 ## Terminology
 * Braces - `{` and `}`

--- a/src/dfmt/config.d
+++ b/src/dfmt/config.d
@@ -57,6 +57,8 @@ struct Config
     OptionalBoolean dfmt_single_template_constraint_indent;
     ///
     OptionalBoolean dfmt_space_before_aa_colon;
+    ///
+    OptionalBoolean dfmt_keep_line_breaks;
 
     mixin StandardEditorConfigFields;
 
@@ -85,6 +87,7 @@ struct Config
         dfmt_template_constraint_style = TemplateConstraintStyle.conditional_newline_indent;
         dfmt_single_template_constraint_indent = OptionalBoolean.f;
         dfmt_space_before_aa_colon = OptionalBoolean.f;
+        dfmt_keep_line_breaks = OptionalBoolean.f;
     }
 
     /**

--- a/src/dfmt/main.d
+++ b/src/dfmt/main.d
@@ -92,6 +92,9 @@ else
             case "space_before_aa_colon":
                 optConfig.dfmt_space_before_aa_colon = optVal;
                 break;
+            case "keep_line_breaks":
+                optConfig.dfmt_keep_line_breaks = optVal;
+                break;
             default:
                 assert(false, "Invalid command-line switch");
             }
@@ -121,7 +124,8 @@ else
                 "single_template_constraint_indent", &handleBooleans,
                 "space_before_aa_colon", &handleBooleans,
                 "tab_width", &optConfig.tab_width,
-                "template_constraint_style", &optConfig.dfmt_template_constraint_style);
+                "template_constraint_style", &optConfig.dfmt_template_constraint_style,
+                "keep_line_breaks", &handleBooleans);
             // dfmt on
         }
         catch (GetOptException e)
@@ -308,6 +312,7 @@ Formatting Options:
     --indent_size
     --indent_style, -t          `,
             optionsToString!(typeof(Config.indent_style)), `
+    --keep_line_breaks
     --soft_max_line_length
     --max_line_length
     --outdent_attributes

--- a/tests/allman/keep_line_breaks.d.ref
+++ b/tests/allman/keep_line_breaks.d.ref
@@ -1,0 +1,29 @@
+@safe nothrow
+@Read
+@NonNull
+public
+int[] func(int argument_1_1, int argument_1_2,
+        int argument_2_1, int argument_2_2,
+        int argument_3_1, int argument_3_2)
+{
+    if (true && true
+            && true && true
+            && true && true)
+    {
+    }
+    else if (true && true &&
+            true && true &&
+            true && true)
+    {
+    }
+
+    func(argument_1_1).func(argument_1_2)
+        .func(argument_2_1)
+        .func(argument_2_2);
+
+    return [
+        3, 5,
+        5, 7,
+        11, 13,
+    ];
+}

--- a/tests/keep_line_breaks.args
+++ b/tests/keep_line_breaks.args
@@ -1,0 +1,1 @@
+--keep_line_breaks true

--- a/tests/keep_line_breaks.d
+++ b/tests/keep_line_breaks.d
@@ -1,0 +1,29 @@
+@safe nothrow
+@Read
+@NonNull
+public
+int[] func(int argument_1_1, int argument_1_2,
+        int argument_2_1, int argument_2_2,
+        int argument_3_1, int argument_3_2)
+{
+    if (true && true
+            && true && true
+            && true && true)
+    {
+    }
+    else if (true && true &&
+            true && true &&
+            true && true)
+    {
+    }
+
+    func(argument_1_1).func(argument_1_2)
+        .func(argument_2_1)
+        .func(argument_2_2);
+
+    return [
+        3, 5,
+        5, 7,
+        11, 13,
+    ];
+}

--- a/tests/otbs/keep_line_breaks.d.ref
+++ b/tests/otbs/keep_line_breaks.d.ref
@@ -1,0 +1,25 @@
+@safe nothrow
+@Read
+@NonNull
+public
+int[] func(int argument_1_1, int argument_1_2,
+        int argument_2_1, int argument_2_2,
+        int argument_3_1, int argument_3_2) {
+    if (true && true
+            && true && true
+            && true && true) {
+    } else if (true && true &&
+            true && true &&
+            true && true) {
+    }
+
+    func(argument_1_1).func(argument_1_2)
+        .func(argument_2_1)
+        .func(argument_2_2);
+
+    return [
+        3, 5,
+        5, 7,
+        11, 13,
+    ];
+}


### PR DESCRIPTION
Adds a new option, --keep_line_breaks, which preserves line breaks at many places, where custom formatting may be desirable.

Related issues:
- https://github.com/dlang-community/dfmt/issues/270
- https://github.com/dlang-community/dfmt/issues/463