### PR TITLE
keep_line_breaks: multi-line tokens and argument list break

### DIFF
--- a/src/dfmt/formatter.d
+++ b/src/dfmt/formatter.d
@@ -1574,13 +1574,6 @@ private:
             newline();
             regenLineBreakHints(index - 1);
         }
-        else if (!peekIs(tok!"}") && (linebreakHints.canFind(index)
-                || (linebreakHints.length == 0 && currentLineLength > config.max_line_length)))
-        {
-            pushWrapIndent();
-            writeToken();
-            newline();
-        }
         else if (config.dfmt_keep_line_breaks == OptionalBoolean.t)
         {
             const commaLine = tokens[index].line;
@@ -1598,6 +1591,13 @@ private:
                     newline();
                 }
             }
+        }
+        else if (!peekIs(tok!"}") && (linebreakHints.canFind(index)
+                || (linebreakHints.length == 0 && currentLineLength > config.max_line_length)))
+        {
+            pushWrapIndent();
+            writeToken();
+            newline();
         }
         else
         {

--- a/src/dfmt/formatter.d
+++ b/src/dfmt/formatter.d
@@ -2151,10 +2151,22 @@ const pure @safe @nogc:
     bool onNextLine() @nogc nothrow pure @safe
     {
         import dfmt.editorconfig : OptionalBoolean;
+        import std.algorithm.searching : count;
+        import std.string : representation;
 
-        return config.dfmt_keep_line_breaks == OptionalBoolean.t
-            && index > 0
-            && tokens[index - 1].line < tokens[index].line;
+        if (config.dfmt_keep_line_breaks == OptionalBoolean.f || index <= 0)
+        {
+            return false;
+        }
+        // To compare whether 2 tokens are on same line, we need the end line
+        // of the first token (tokens[index - 1]) and the start line of the
+        // second one (tokens[index]). If a token takes multiple lines (e.g. a
+        // multi-line string), we can sum the number of the newlines in the
+        // token and tokens[index - 1].line, the start line.
+        const previousTokenEndLineNo = tokens[index - 1].line
+                + tokens[index - 1].text.representation.count('\n');
+
+        return previousTokenEndLineNo < tokens[index].line;
     }
 
     /// Bugs: not unicode correct

--- a/tests/allman/keep_line_breaks.d.ref
+++ b/tests/allman/keep_line_breaks.d.ref
@@ -21,6 +21,10 @@ int[] func(int argument_1_1, int argument_1_2,
         .func(argument_2_1)
         .func(argument_2_2);
 
+    auto x = func(argument_1_1, argument_1_2,
+            this.argument_2_1, this.argument_2_2,
+            argument_3_1, argument_3_2);
+
     return [
         3, 5,
         5, 7,

--- a/tests/allman/keep_line_breaks.d.ref
+++ b/tests/allman/keep_line_breaks.d.ref
@@ -25,6 +25,11 @@ int[] func(int argument_1_1, int argument_1_2,
             this.argument_2_1, this.argument_2_2,
             argument_3_1, argument_3_2);
 
+    `
+        <html>
+        </html>
+    `.format!"%s";
+
     return [
         3, 5,
         5, 7,

--- a/tests/keep_line_breaks.d
+++ b/tests/keep_line_breaks.d
@@ -21,6 +21,10 @@ int[] func(int argument_1_1, int argument_1_2,
         .func(argument_2_1)
         .func(argument_2_2);
 
+    auto x = func(argument_1_1, argument_1_2,
+            this.argument_2_1, this.argument_2_2,
+            argument_3_1, argument_3_2);
+
     return [
         3, 5,
         5, 7,

--- a/tests/keep_line_breaks.d
+++ b/tests/keep_line_breaks.d
@@ -25,6 +25,11 @@ int[] func(int argument_1_1, int argument_1_2,
             this.argument_2_1, this.argument_2_2,
             argument_3_1, argument_3_2);
 
+    `
+        <html>
+        </html>
+    `.format!"%s";
+
     return [
         3, 5,
         5, 7,

--- a/tests/otbs/keep_line_breaks.d.ref
+++ b/tests/otbs/keep_line_breaks.d.ref
@@ -17,6 +17,10 @@ int[] func(int argument_1_1, int argument_1_2,
         .func(argument_2_1)
         .func(argument_2_2);
 
+    auto x = func(argument_1_1, argument_1_2,
+            this.argument_2_1, this.argument_2_2,
+            argument_3_1, argument_3_2);
+
     return [
         3, 5,
         5, 7,

--- a/tests/otbs/keep_line_breaks.d.ref
+++ b/tests/otbs/keep_line_breaks.d.ref
@@ -21,6 +21,11 @@ int[] func(int argument_1_1, int argument_1_2,
             this.argument_2_1, this.argument_2_2,
             argument_3_1, argument_3_2);
 
+    `
+        <html>
+        </html>
+    `.format!"%s";
+
     return [
         3, 5,
         5, 7,


### PR DESCRIPTION
--keep_line_breaks only (diffs are the result without this PR).

Fixes line breaks in some argument lists:

```diff
     auto x = func(argument_1_1, argument_1_2,
-            this.argument_2_1, this.argument_2_2,
+            this.argument_2_1,
+            this.argument_2_2,
             argument_3_1, argument_3_2);
 ```

and multi-line tokens:

```diff
 
 `
     <html>
     </html>
-`.format!"%s";
+`
+    .format!"%s";
 
```