### PR TITLE
use test_with_package.d for libdparse for tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "stdx-allocator"]
 	path = stdx-allocator
 	url = https://github.com/dlang-community/stdx-allocator
+[submodule "d-test-utils"]
+	path = d-test-utils
+	url = https://github.com/dlang-community/d-test-utils.git

--- a/.travis.sh
+++ b/.travis.sh
@@ -3,7 +3,7 @@
 set -e
 
 if [[ $BUILD == dub ]]; then
-    dub build --build=release
+    rdmd ./d-test-utils/test_with_package.d $LIBDPARSE_VERSION libdparse -- dub build --build=release
 elif [[ $DC == ldc2 ]]; then
     git submodule update --init --recursive
     make ldc -j2

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ branches:
 
 env:
   - BUILD=
-  - BUILD=dub
+  - BUILD=dub LIBDPARSE_VERSION=min
+  - BUILD=dub LIBDPARSE_VERSION=max
 
 script: ./.travis.sh
 


### PR DESCRIPTION
test both minimum and maximum allowed libdparse versions with dub

Not so useful right now with there only being one version matching ~>0.14.0 but very useful when dfmt allows a larger range of libdparse versions or when new patches for libdparse versions come out.

See https://github.com/dlang-community/libddoc/pull/47