### PR TITLE
Upgrade libdparse to <0.16.0

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -4,7 +4,7 @@
     "targetType": "autodetect",
     "license": "BSL-1.0",
     "dependencies": {
-      "libdparse": "~>0.14.0"
+      "libdparse": ">=0.14.0 <0.16.0"
     },
     "targetPath" : "bin/",
     "targetName" : "dfmt",


### PR DESCRIPTION
because of the new CI test script both minimum and maximum versions are tested for wider compatibility