### PR TITLE
Fix issue 483: indent continuing case statements on the same level

### DIFF
--- a/src/dfmt/formatter.d
+++ b/src/dfmt/formatter.d
@@ -1713,7 +1713,14 @@ private:
             }
             else if (currentIs(tok!"case") || currentIs(tok!"default"))
             {
-                if (peekBackIs(tok!"}", true) || peekBackIs(tok!";", true))
+
+                if (peekBackIs(tok!"}", true) || peekBackIs(tok!";", true)
+                    /**
+                     * The following code is valid and should be indented flatly
+                     * case A:
+                     * case B:
+                     */
+                    || peekBackIs(tok!":", true))
                 {
                     indents.popTempIndents();
                     if (indents.topIs(tok!"case"))

--- a/tests/allman/issue0483.d.ref
+++ b/tests/allman/issue0483.d.ref
@@ -1,0 +1,15 @@
+module tests.issue0483;
+
+void main()
+{
+    switch (0)
+    {
+        case 1:
+        case 2:
+    label:
+        case 3:
+            break;
+        default:
+            break;
+    }
+}

--- a/tests/issue0483.args
+++ b/tests/issue0483.args
@@ -1,0 +1,1 @@
+--align_switch_statements=false

--- a/tests/issue0483.d
+++ b/tests/issue0483.d
@@ -1,0 +1,15 @@
+module tests.issue0483;
+
+void main()
+{
+    switch (0)
+    {
+        case 1:
+        case 2:
+    label:
+        case 3:
+            break;
+        default:
+            break;
+    }
+}

--- a/tests/otbs/issue0483.d.ref
+++ b/tests/otbs/issue0483.d.ref
@@ -1,0 +1,13 @@
+module tests.issue0483;
+
+void main() {
+    switch (0) {
+        case 1:
+        case 2:
+    label:
+        case 3:
+            break;
+        default:
+            break;
+    }
+}


### PR DESCRIPTION
Expected:

```
  switch (foo) {
    case A:
    case B:
      break;
  }
```

Got:

```
  switch (foo) {
    case A:
      case B:
      break;
  }
```
