### PR TITLE
Fix issue 497: insert space before function/delegate in function type that returns template instantiated with parenless value argument

### DIFF
--- a/src/dfmt/formatter.d
+++ b/src/dfmt/formatter.d
@@ -211,7 +211,9 @@ private:
             {
                 immutable t = tokens[index].type;
                 if (t == tok!"identifier" || isStringLiteral(t)
-                        || isNumberLiteral(t) || t == tok!"characterLiteral")
+                        || isNumberLiteral(t) || t == tok!"characterLiteral"
+                        // a!"b" function()
+                        || t == tok!"function" || t == tok!"delegate")
                     write(" ");
             }
         }

--- a/tests/allman/issue0497.d.ref
+++ b/tests/allman/issue0497.d.ref
@@ -1,0 +1,5 @@
+alias f1 = S function();
+alias f2 = S!"foo" function();
+alias f3 = S!5 function();
+alias f4 = S!S function();
+alias f5 = S!(S) function();

--- a/tests/issue0497.d
+++ b/tests/issue0497.d
@@ -1,0 +1,5 @@
+alias f1 = S function();
+alias f2 = S!"foo" function();
+alias f3 = S!5 function();
+alias f4 = S!S function();
+alias f5 = S!(S) function();

--- a/tests/otbs/issue0497.d.ref
+++ b/tests/otbs/issue0497.d.ref
@@ -1,0 +1,5 @@
+alias f1 = S function();
+alias f2 = S!"foo" function();
+alias f3 = S!5 function();
+alias f4 = S!S function();
+alias f5 = S!(S) function();


### PR DESCRIPTION
Implement `S!5 function()" by inserting an additional space for "literal followed by function/delegate".
