### PR TITLE
Break line on multiline strings

### DIFF
--- a/src/dfmt/wrapping.d
+++ b/src/dfmt/wrapping.d
@@ -172,9 +172,6 @@ size_t[] chooseLineBreakTokens(size_t index, const Token[] tokens,
 void validMoves(OR)(auto ref OR output, const Token[] tokens, immutable short[] depths,
         uint current, const Config* config, int currentLineLength, int indentLevel)
 {
-    import std.algorithm : sort, canFind, min;
-    import std.array : insertInPlace;
-
     foreach (i, token; tokens)
     {
         if (!isBreakToken(token.type) || (((1 << i) & current) != 0))

--- a/tests/allman/issue0476.d.ref
+++ b/tests/allman/issue0476.d.ref
@@ -1,0 +1,7 @@
+string BuildForwardCall()
+{
+    return `static if (is(typeof(mocked___.` ~ methodString ~ argsPassed ~ `)))
+            {
+                return (mocked___.` ~ methodString ~ argsPassed ~ `);
+            }`;
+}

--- a/tests/issue0476.d
+++ b/tests/issue0476.d
@@ -1,0 +1,7 @@
+string BuildForwardCall()
+{
+    return `static if (is(typeof(mocked___.` ~ methodString ~ argsPassed ~ `)))
+            {
+                return (mocked___.` ~ methodString ~ argsPassed ~ `);
+            }`;
+}

--- a/tests/otbs/issue0476.d.ref
+++ b/tests/otbs/issue0476.d.ref
@@ -1,0 +1,6 @@
+string BuildForwardCall() {
+    return `static if (is(typeof(mocked___.` ~ methodString ~ argsPassed ~ `)))
+            {
+                return (mocked___.` ~ methodString ~ argsPassed ~ `);
+            }`;
+}


### PR DESCRIPTION
2 Bugs:

- `chooseLineBreakTokens` expects to get tokens of a single line. But since a string with newlines is a single token, the newlines inside it weren't acknowledged. Further `chooseLineBreakTokens` calculates the length of the tokens by using `tokens.map!(a => tokenLength(a)).sum()`. `tokenLength()` takes only the length of the string literal before the newline (which is actually correct if no other tokens forllow the string).
- `currentLineLength += cast(uint) o; // where o is the length of the string after the last newline`. `currentLineLength` should be just `o` since the length is just the length on the string on the new line without the length of the tokens on the previous line.