### PR TITLE
Keep line breaks in UFCS chains

### DIFF
--- a/src/dfmt/formatter.d
+++ b/src/dfmt/formatter.d
@@ -1401,7 +1401,8 @@ private:
             break;
         case tok!".":
             regenLineBreakHintsIfNecessary(index);
-            immutable bool ufcsWrap = astInformation.ufcsHintLocations.canFindIndex(current.index);
+            immutable bool ufcsWrap = config.dfmt_keep_line_breaks == OptionalBoolean.f
+                    && astInformation.ufcsHintLocations.canFindIndex(current.index);
             if (ufcsWrap || linebreakHints.canFind(index) || onNextLine
                     || (linebreakHints.length == 0 && currentLineLength + nextTokenLength() > config.max_line_length))
             {

--- a/tests/allman/issue0503.d.ref
+++ b/tests/allman/issue0503.d.ref
@@ -1,0 +1,15 @@
+string f()
+{
+    return duration.total!"seconds".to!string;
+}
+
+string g()
+{
+    return duration.total!"seconds"().to!string;
+}
+
+string h()
+{
+    return duration.total!"seconds"().to!string.to!string.to!string.to!string.to!string.to!string
+        .to!string.to!string.to!string;
+}

--- a/tests/issue0503.args
+++ b/tests/issue0503.args
@@ -1,0 +1,1 @@
+--keep_line_breaks=true

--- a/tests/issue0503.d
+++ b/tests/issue0503.d
@@ -1,0 +1,14 @@
+string f()
+{
+    return duration.total!"seconds".to!string;
+}
+
+string g()
+{
+    return duration.total!"seconds"().to!string;
+}
+
+string h()
+{
+    return duration.total!"seconds"().to!string.to!string.to!string.to!string.to!string.to!string.to!string.to!string.to!string;
+}

--- a/tests/otbs/issue0503.d.ref
+++ b/tests/otbs/issue0503.d.ref
@@ -1,0 +1,12 @@
+string f() {
+    return duration.total!"seconds".to!string;
+}
+
+string g() {
+    return duration.total!"seconds"().to!string;
+}
+
+string h() {
+    return duration.total!"seconds"().to!string.to!string.to!string.to!string.to!string.to!string
+        .to!string.to!string.to!string;
+}


### PR DESCRIPTION
Fixes #503.

I looked at the code and dfmt makes best effort to recognize what is a UFCS chain. I'm not sure what is the correct behaviour. But --keep_line_breaks adding an additional newline is definitely a bug, so I fixed only that part.