### PR TITLE
Don't output an extra newline after a comment

### DIFF
--- a/src/dfmt/formatter.d
+++ b/src/dfmt/formatter.d
@@ -1406,7 +1406,8 @@ private:
                     || (linebreakHints.length == 0 && currentLineLength + nextTokenLength() > config.max_line_length))
             {
                 pushWrapIndent();
-                newline();
+                if (!peekBackIs(tok!"comment"))
+                    newline();
                 if (ufcsWrap || onNextLine)
                     regenLineBreakHints(index);
             }
@@ -1468,7 +1469,8 @@ private:
                 {
                     if (!indents.topIs(tok!"enum"))
                         pushWrapIndent();
-                    newline();
+                    if (!peekBackIs(tok!"comment"))
+                        newline();
                 }
                 else
                 {
@@ -1483,7 +1485,8 @@ private:
 
                 if (rightOperandLine > operatorLine)
                 {
-                    newline();
+                    if (!peekBackIs(tok!"comment"))
+                        newline();
                 }
                 else
                 {

--- a/tests/allman/issue0509.d.ref
+++ b/tests/allman/issue0509.d.ref
@@ -1,0 +1,34 @@
+void main()
+{
+    string a = "foo"
+        ~ "bar" // bar
+        ~ "baz";
+}
+
+void foo()
+{
+    afdsafds
+        .asdf // blah
+        .flub;
+}
+
+void main()
+{
+    string a = "foo"
+        ~ "bar" /* bar */
+        ~ "baz";
+}
+
+void foo()
+{
+    afdsafds
+        .asdf /* blah */
+        .flub;
+}
+
+void foo() // hello
+{ // world
+    // ok
+    writeln("hi"); // hi!
+} // done
+//finish

--- a/tests/issue0509.args
+++ b/tests/issue0509.args
@@ -1,0 +1,1 @@
+--keep_line_breaks=true

--- a/tests/issue0509.d
+++ b/tests/issue0509.d
@@ -1,0 +1,34 @@
+void main()
+{
+    string a = "foo"
+        ~ "bar" // bar
+        ~ "baz";
+}
+
+void foo()
+{
+    afdsafds
+        .asdf // blah
+        .flub;
+}
+
+void main()
+{
+    string a = "foo"
+        ~ "bar" /* bar */
+        ~ "baz";
+}
+
+void foo()
+{
+    afdsafds
+        .asdf /* blah */
+        .flub;
+}
+
+void foo() // hello
+{ // world
+    // ok
+    writeln("hi"); // hi!
+} // done
+//finish

--- a/tests/otbs/issue0509.d.ref
+++ b/tests/otbs/issue0509.d.ref
@@ -1,0 +1,30 @@
+void main() {
+    string a = "foo"
+        ~ "bar" // bar
+        ~ "baz";
+}
+
+void foo() {
+    afdsafds
+        .asdf // blah
+        .flub;
+}
+
+void main() {
+    string a = "foo"
+        ~ "bar" /* bar */
+        ~ "baz";
+}
+
+void foo() {
+    afdsafds
+        .asdf /* blah */
+        .flub;
+}
+
+void foo() // hello
+{ // world
+    // ok
+    writeln("hi"); // hi!
+} // done
+//finish


### PR DESCRIPTION
Fixes #509 and #490.