### PR TITLE
Don't indent associative array keys as labels

### DIFF
--- a/src/dfmt/formatter.d
+++ b/src/dfmt/formatter.d
@@ -1692,8 +1692,8 @@ private:
                     assert(l2 != -1, "Recent '{' is not found despite being in struct initializer");
                     indentLevel = l2 + 1;
                 }
-                else if (config.dfmt_compact_labeled_statements == OptionalBoolean.f
-                        || !isBlockHeader(2) || peek2Is(tok!"if"))
+                else if ((config.dfmt_compact_labeled_statements == OptionalBoolean.f
+                        || !isBlockHeader(2) || peek2Is(tok!"if")) && !indents.topIs(tok!"]"))
                 {
                     immutable l2 = indents.indentToMostRecent(tok!"{");
                     indentLevel = l2 != -1 ? l2 : indents.indentLevel - 1;

--- a/tests/allman/assoc_key_indent.d.ref
+++ b/tests/allman/assoc_key_indent.d.ref
@@ -1,0 +1,8 @@
+void main()
+{
+    string key;
+
+    int[string] var = [
+        key: 5
+    ];
+}

--- a/tests/assoc_key_indent.args
+++ b/tests/assoc_key_indent.args
@@ -1,0 +1,1 @@
+--keep_line_breaks=true

--- a/tests/assoc_key_indent.d
+++ b/tests/assoc_key_indent.d
@@ -1,0 +1,8 @@
+void main()
+{
+    string key;
+
+    int[string] var = [
+        key: 5
+    ];
+}

--- a/tests/otbs/assoc_key_indent.d.ref
+++ b/tests/otbs/assoc_key_indent.d.ref
@@ -1,0 +1,7 @@
+void main() {
+    string key;
+
+    int[string] var = [
+        key: 5
+    ];
+}


### PR DESCRIPTION
```diff
  void main()
  {
      string key;

      int[string] var = [
-         key: 5
+ key: 5
      ];
  }
```