### PR TITLE
Fix installation instructions on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ when using the **--inplace** option.
 ### Installing with DUB
 
 ```sh
-> dub fetch --version='~master' dfmt && dub run dfmt -- -h
+> dub fetch dfmt@"~master" && dub run dfmt -- -h
 ```
 
 ### Building from source using Make

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ when using the **--inplace** option.
 ### Installing with DUB
 
 ```sh
-> dub fetch dfmt@"~master" && dub run dfmt -- -h
+> dub run dfmt -- -h
 ```
 
 ### Building from source using Make


### PR DESCRIPTION
Fixes Issue #530.

Also modified single quotes to be double quotes so command runs on Windows command line. Tested on Ubuntu 20.04 and Windows 10.