### PR TITLE
Add single_indent option

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ dfmt_template_constraint_style | **`conditional_newline_indent`** `conditional_n
 dfmt_single_template_constraint_indent | `true`, **`false`** | Set if the constraints are indented by a single tab instead of two. Has only an effect if the style set to `always_newline_indent` or `conditional_newline_indent`.
 dfmt_space_before_aa_colon | `true`, **`false`** | Adds a space after an associative array key before the `:` like in older dfmt versions.
 dfmt_keep_line_breaks | `true`, **`false`** | Keep existing line breaks if these don't violate other formatting rules.
+dfmt_single_indent | `true`, **`false`** | Set if the code in parens is indented by a single tab instead of two.
 
 ## Terminology
 * Braces - `{` and `}`

--- a/src/dfmt/config.d
+++ b/src/dfmt/config.d
@@ -59,6 +59,8 @@ struct Config
     OptionalBoolean dfmt_space_before_aa_colon;
     ///
     OptionalBoolean dfmt_keep_line_breaks;
+    ///
+    OptionalBoolean dfmt_single_indent;
 
     mixin StandardEditorConfigFields;
 
@@ -88,6 +90,7 @@ struct Config
         dfmt_single_template_constraint_indent = OptionalBoolean.f;
         dfmt_space_before_aa_colon = OptionalBoolean.f;
         dfmt_keep_line_breaks = OptionalBoolean.f;
+        dfmt_single_indent = OptionalBoolean.f;
     }
 
     /**

--- a/src/dfmt/formatter.d
+++ b/src/dfmt/formatter.d
@@ -110,6 +110,7 @@ struct TokenFormatter(OutputRange)
         this.output = output;
         this.astInformation = astInformation;
         this.config = config;
+        this.indents = IndentStack(config);
 
         {
             auto eol = config.end_of_line;

--- a/src/dfmt/main.d
+++ b/src/dfmt/main.d
@@ -95,6 +95,9 @@ else
             case "keep_line_breaks":
                 optConfig.dfmt_keep_line_breaks = optVal;
                 break;
+            case "single_indent":
+                optConfig.dfmt_single_indent = optVal;
+                break;
             default:
                 assert(false, "Invalid command-line switch");
             }
@@ -125,7 +128,8 @@ else
                 "space_before_aa_colon", &handleBooleans,
                 "tab_width", &optConfig.tab_width,
                 "template_constraint_style", &optConfig.dfmt_template_constraint_style,
-                "keep_line_breaks", &handleBooleans);
+                "keep_line_breaks", &handleBooleans,
+                "single_indent", &handleBooleans);
             // dfmt on
         }
         catch (GetOptException e)
@@ -329,6 +333,7 @@ Formatting Options:
     --compact_labeled_statements
     --template_constraint_style
     --space_before_aa_colon
+    --single_indent
         `,
             optionsToString!(typeof(Config.dfmt_template_constraint_style)));
 }

--- a/tests/allman/keep_single_indent.d.ref
+++ b/tests/allman/keep_single_indent.d.ref
@@ -1,0 +1,49 @@
+unittest
+{
+    {
+        bool anotherTemplatedFunction(One, Two, Three)(One alpha, Two bravo,
+            Three charlie, double delta)
+        {
+            if (isNumeric!One && isNumeric!Two && isNumeric!Three && echo
+                && foxtrot && golf && hotel && india && juliet)
+            {
+            }
+        }
+    }
+}
+
+void f()
+{
+    string a = "foo"
+        ~ "bar" /* bar */
+        ~ "baz";
+}
+
+unittest
+{
+    if (a)
+    {
+        while (sBraceDepth == 0 && indents.topIsTemp()
+            && ((indents.top != tok!"if" && indents.top != tok!"version")
+                || !peekIs(tok!"else")))
+            a();
+    }
+}
+
+unittest
+{
+    callFunc({ int i = 10; return i; });
+    callFunc({
+        int i = 10;
+        foo(alpha, bravo, charlie, delta, echo, foxtrot, golf, echo);
+        doStuff(withThings, andOtherStuff);
+        return i;
+    });
+    callFunc({
+        int i = 10;
+        foo(alpha_longVarName, bravo_longVarName, charlie_longVarName, delta_longVarName,
+            echo_longVarName, foxtrot_longVarName, golf_longVarName, echo_longVarName);
+        doStuff(withThings, andOtherStuff);
+        return i;
+    }, more_stuff);
+}

--- a/tests/allman/single_indent.d.ref
+++ b/tests/allman/single_indent.d.ref
@@ -1,0 +1,41 @@
+unittest
+{
+    {
+        bool anotherTemplatedFunction(One, Two, Three)(One alpha, Two bravo,
+            Three charlie, double delta)
+        {
+            if (isNumeric!One && isNumeric!Two && isNumeric!Three && echo
+                && foxtrot && golf && hotel && india && juliet)
+            {
+            }
+        }
+    }
+}
+
+unittest
+{
+    if (a)
+    {
+        while (sBraceDepth == 0 && indents.topIsTemp()
+            && ((indents.top != tok!"if" && indents.top != tok!"version") || !peekIs(tok!"else")))
+            a();
+    }
+}
+
+unittest
+{
+    callFunc({ int i = 10; return i; });
+    callFunc({
+        int i = 10;
+        foo(alpha, bravo, charlie, delta, echo, foxtrot, golf, echo);
+        doStuff(withThings, andOtherStuff);
+        return i;
+    });
+    callFunc({
+        int i = 10;
+        foo(alpha_longVarName, bravo_longVarName, charlie_longVarName, delta_longVarName,
+            echo_longVarName, foxtrot_longVarName, golf_longVarName, echo_longVarName);
+        doStuff(withThings, andOtherStuff);
+        return i;
+    }, more_stuff);
+}

--- a/tests/keep_single_indent.args
+++ b/tests/keep_single_indent.args
@@ -1,0 +1,2 @@
+--single_indent true
+--keep_line_breaks true

--- a/tests/keep_single_indent.d
+++ b/tests/keep_single_indent.d
@@ -1,0 +1,49 @@
+unittest
+{
+    {
+        bool anotherTemplatedFunction(One, Two, Three)(One alpha, Two bravo,
+                Three charlie, double delta)
+        {
+            if (isNumeric!One && isNumeric!Two && isNumeric!Three && echo
+                    && foxtrot && golf && hotel && india && juliet)
+            {
+            }
+        }
+    }
+}
+
+void f()
+{
+    string a = "foo"
+        ~ "bar" /* bar */
+        ~ "baz";
+}
+
+unittest
+{
+    if (a)
+    {
+        while (sBraceDepth == 0 && indents.topIsTemp()
+                && ((indents.top != tok!"if" && indents.top != tok!"version")
+                    || !peekIs(tok!"else")))
+            a();
+    }
+}
+
+unittest
+{
+    callFunc({ int i = 10; return i; });
+    callFunc({
+        int i = 10;
+        foo(alpha, bravo, charlie, delta, echo, foxtrot, golf, echo);
+        doStuff(withThings, andOtherStuff);
+        return i;
+    });
+    callFunc({
+        int i = 10;
+        foo(alpha_longVarName, bravo_longVarName, charlie_longVarName, delta_longVarName,
+                echo_longVarName, foxtrot_longVarName, golf_longVarName, echo_longVarName);
+        doStuff(withThings, andOtherStuff);
+        return i;
+    }, more_stuff);
+}

--- a/tests/otbs/keep_single_indent.d.ref
+++ b/tests/otbs/keep_single_indent.d.ref
@@ -1,0 +1,42 @@
+unittest {
+    {
+        bool anotherTemplatedFunction(One, Two, Three)(One alpha, Two bravo,
+            Three charlie, double delta) {
+            if (isNumeric!One && isNumeric!Two && isNumeric!Three && echo
+                && foxtrot && golf && hotel && india && juliet) {
+            }
+        }
+    }
+}
+
+void f() {
+    string a = "foo"
+        ~ "bar" /* bar */
+        ~ "baz";
+}
+
+unittest {
+    if (a) {
+        while (sBraceDepth == 0 && indents.topIsTemp()
+            && ((indents.top != tok!"if" && indents.top != tok!"version")
+                || !peekIs(tok!"else")))
+            a();
+    }
+}
+
+unittest {
+    callFunc({ int i = 10; return i; });
+    callFunc({
+        int i = 10;
+        foo(alpha, bravo, charlie, delta, echo, foxtrot, golf, echo);
+        doStuff(withThings, andOtherStuff);
+        return i;
+    });
+    callFunc({
+        int i = 10;
+        foo(alpha_longVarName, bravo_longVarName, charlie_longVarName, delta_longVarName,
+            echo_longVarName, foxtrot_longVarName, golf_longVarName, echo_longVarName);
+        doStuff(withThings, andOtherStuff);
+        return i;
+    }, more_stuff);
+}

--- a/tests/otbs/single_indent.d.ref
+++ b/tests/otbs/single_indent.d.ref
@@ -1,0 +1,35 @@
+unittest {
+    {
+        bool anotherTemplatedFunction(One, Two, Three)(One alpha, Two bravo,
+            Three charlie, double delta) {
+            if (isNumeric!One && isNumeric!Two && isNumeric!Three && echo
+                && foxtrot && golf && hotel && india && juliet) {
+            }
+        }
+    }
+}
+
+unittest {
+    if (a) {
+        while (sBraceDepth == 0 && indents.topIsTemp()
+            && ((indents.top != tok!"if" && indents.top != tok!"version") || !peekIs(tok!"else")))
+            a();
+    }
+}
+
+unittest {
+    callFunc({ int i = 10; return i; });
+    callFunc({
+        int i = 10;
+        foo(alpha, bravo, charlie, delta, echo, foxtrot, golf, echo);
+        doStuff(withThings, andOtherStuff);
+        return i;
+    });
+    callFunc({
+        int i = 10;
+        foo(alpha_longVarName, bravo_longVarName, charlie_longVarName, delta_longVarName,
+            echo_longVarName, foxtrot_longVarName, golf_longVarName, echo_longVarName);
+        doStuff(withThings, andOtherStuff);
+        return i;
+    }, more_stuff);
+}

--- a/tests/single_indent.args
+++ b/tests/single_indent.args
@@ -1,0 +1,1 @@
+--single_indent true

--- a/tests/single_indent.d
+++ b/tests/single_indent.d
@@ -1,0 +1,42 @@
+unittest
+{
+    {
+        bool anotherTemplatedFunction(One, Two, Three)(One alpha, Two bravo,
+                Three charlie, double delta)
+        {
+            if (isNumeric!One && isNumeric!Two && isNumeric!Three && echo
+                    && foxtrot && golf && hotel && india && juliet)
+            {
+            }
+        }
+    }
+}
+
+unittest
+{
+    if (a)
+    {
+        while (sBraceDepth == 0 && indents.topIsTemp()
+                && ((indents.top != tok!"if" && indents.top != tok!"version")
+                    || !peekIs(tok!"else")))
+            a();
+    }
+}
+
+unittest
+{
+    callFunc({ int i = 10; return i; });
+    callFunc({
+        int i = 10;
+        foo(alpha, bravo, charlie, delta, echo, foxtrot, golf, echo);
+        doStuff(withThings, andOtherStuff);
+        return i;
+    });
+    callFunc({
+        int i = 10;
+        foo(alpha_longVarName, bravo_longVarName, charlie_longVarName, delta_longVarName,
+                echo_longVarName, foxtrot_longVarName, golf_longVarName, echo_longVarName);
+        doStuff(withThings, andOtherStuff);
+        return i;
+    }, more_stuff);
+}


### PR DESCRIPTION
Since the DStyle proposal to indent continuation lines by two tabs instead of
one was rejected (see https://github.com/dlang/dlang.org/pull/2766), and it is
the only behaviour dfmt supports, I suggest to add an option to indent
everything with a single tab. So the option changes the indentation inside the
parens.

Double indentation is useful to visually emphasize a code block after an
argument list or if-, while-conditions and so on. For example

```d
if (true
  && true)
  doSomething();
```
vs

```d
if (true
        & true)
    doSomething();
```

The indentation in the second case makes it clear where the condition ends.

Some style guides enforce:

- curly braces even in single line if-statements
- curly braces on the new line

In  the case of a such style guide, the problem disappears because there is
always a new line between the condition and the code block:

```d
if (true
    && true)
{
    doSomething();
}
```

It also eliminates the need to think about aligning the code with mixed parens,
brackets and braces (e.g. `([])`), just indent everything with one tab.