### PR TITLE
Fix double array indentation inside parens

### DIFF
--- a/src/dfmt/formatter.d
+++ b/src/dfmt/formatter.d
@@ -629,6 +629,10 @@ private:
         }
         else if (arrayInitializerStart && isMultilineAt(index - 1))
         {
+            if (peekBack2Is(tok!"(")) {
+                indents.pop();
+            }
+
             // Use the close bracket as the indent token to distinguish
             // the array initialiazer from an array index in the newline
             // handling code

--- a/tests/allman/array_access.d.ref
+++ b/tests/allman/array_access.d.ref
@@ -1,7 +1,7 @@
 unittest
 {
     foo([
-            target.value.region[1], target.value.region[1],
-            target.value.region[1], target.value.region[1], target.value.region[1]
-            ]);
+        target.value.region[1], target.value.region[1], target.value.region[1],
+        target.value.region[1], target.value.region[1]
+    ]);
 }

--- a/tests/allman/associative_array.d.ref
+++ b/tests/allman/associative_array.d.ref
@@ -1,24 +1,24 @@
 unittest
 {
     Bson base = Bson([
-            "maps": Bson([
-                    Bson(["id": Bson(4), "comment": Bson("hello")]),
-                    Bson(["id": Bson(49), "comment": Bson(null)])
-                ]),
-            "short": Bson(["a": "b", "c": "d"]),
-            "numbers": Bson([
-                    1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
-                    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0
-                ]),
-            "shuffleOnReset": serializeToBson([
-                    "all": false,
-                    "selected": true,
-                    "maybe": false
-                ]),
-            "resetOnEmpty": Bson(false),
-            "applyMods": Bson(true),
-            "sendComments": Bson(true)
-            ]);
+        "maps": Bson([
+            Bson(["id": Bson(4), "comment": Bson("hello")]),
+            Bson(["id": Bson(49), "comment": Bson(null)])
+        ]),
+        "short": Bson(["a": "b", "c": "d"]),
+        "numbers": Bson([
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2,
+            3, 4, 5, 6, 7, 8, 9, 0
+        ]),
+        "shuffleOnReset": serializeToBson([
+            "all": false,
+            "selected": true,
+            "maybe": false
+        ]),
+        "resetOnEmpty": Bson(false),
+        "applyMods": Bson(true),
+        "sendComments": Bson(true)
+    ]);
     int[] x = [
         1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3,
         4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0

--- a/tests/allman/associative_array_complex.d.ref
+++ b/tests/allman/associative_array_complex.d.ref
@@ -1,25 +1,25 @@
 auto find()
 {
     return Map.findRange([
-            "$and": [
-                ["deleted": Bson(false)],
-                [
-                    "$or": Bson([
-                            serializeToBson(["forceUpdate": Bson(true)]),
-                            serializeToBson([
-                                "info.approved": ["$eq": Bson(1)],
-                                "fetchDate": [
-                                    "$lte": Bson(BsonDate(currentTime - 60.days))
-                                ]
-                            ]),
-                            serializeToBson([
-                                "info.approved": ["$ne": Bson(1)],
-                                "fetchDate": [
-                                    "$lte": Bson(BsonDate(currentTime - 14.days))
-                                ]
-                            ])
-                        ])
-                ]
+        "$and": [
+            ["deleted": Bson(false)],
+            [
+                "$or": Bson([
+                    serializeToBson(["forceUpdate": Bson(true)]),
+                    serializeToBson([
+                        "info.approved": ["$eq": Bson(1)],
+                        "fetchDate": [
+                            "$lte": Bson(BsonDate(currentTime - 60.days))
+                        ]
+                    ]),
+                    serializeToBson([
+                        "info.approved": ["$ne": Bson(1)],
+                        "fetchDate": [
+                            "$lte": Bson(BsonDate(currentTime - 14.days))
+                        ]
+                    ])
+                ])
             ]
-            ]);
+        ]
+    ]);
 }

--- a/tests/otbs/array_access.d.ref
+++ b/tests/otbs/array_access.d.ref
@@ -1,6 +1,6 @@
 unittest {
     foo([
-            target.value.region[1], target.value.region[1],
-            target.value.region[1], target.value.region[1], target.value.region[1]
-            ]);
+        target.value.region[1], target.value.region[1], target.value.region[1],
+        target.value.region[1], target.value.region[1]
+    ]);
 }

--- a/tests/otbs/associative_array.d.ref
+++ b/tests/otbs/associative_array.d.ref
@@ -1,23 +1,23 @@
 unittest {
     Bson base = Bson([
-            "maps": Bson([
-                    Bson(["id": Bson(4), "comment": Bson("hello")]),
-                    Bson(["id": Bson(49), "comment": Bson(null)])
-                ]),
-            "short": Bson(["a": "b", "c": "d"]),
-            "numbers": Bson([
-                    1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
-                    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0
-                ]),
-            "shuffleOnReset": serializeToBson([
-                    "all": false,
-                    "selected": true,
-                    "maybe": false
-                ]),
-            "resetOnEmpty": Bson(false),
-            "applyMods": Bson(true),
-            "sendComments": Bson(true)
-            ]);
+        "maps": Bson([
+            Bson(["id": Bson(4), "comment": Bson("hello")]),
+            Bson(["id": Bson(49), "comment": Bson(null)])
+        ]),
+        "short": Bson(["a": "b", "c": "d"]),
+        "numbers": Bson([
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2,
+            3, 4, 5, 6, 7, 8, 9, 0
+        ]),
+        "shuffleOnReset": serializeToBson([
+            "all": false,
+            "selected": true,
+            "maybe": false
+        ]),
+        "resetOnEmpty": Bson(false),
+        "applyMods": Bson(true),
+        "sendComments": Bson(true)
+    ]);
     int[] x = [
         1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3,
         4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0

--- a/tests/otbs/associative_array_complex.d.ref
+++ b/tests/otbs/associative_array_complex.d.ref
@@ -1,24 +1,24 @@
 auto find() {
     return Map.findRange([
-            "$and": [
-                ["deleted": Bson(false)],
-                [
-                    "$or": Bson([
-                            serializeToBson(["forceUpdate": Bson(true)]),
-                            serializeToBson([
-                                "info.approved": ["$eq": Bson(1)],
-                                "fetchDate": [
-                                    "$lte": Bson(BsonDate(currentTime - 60.days))
-                                ]
-                            ]),
-                            serializeToBson([
-                                "info.approved": ["$ne": Bson(1)],
-                                "fetchDate": [
-                                    "$lte": Bson(BsonDate(currentTime - 14.days))
-                                ]
-                            ])
-                        ])
-                ]
+        "$and": [
+            ["deleted": Bson(false)],
+            [
+                "$or": Bson([
+                    serializeToBson(["forceUpdate": Bson(true)]),
+                    serializeToBson([
+                        "info.approved": ["$eq": Bson(1)],
+                        "fetchDate": [
+                            "$lte": Bson(BsonDate(currentTime - 60.days))
+                        ]
+                    ]),
+                    serializeToBson([
+                        "info.approved": ["$ne": Bson(1)],
+                        "fetchDate": [
+                            "$lte": Bson(BsonDate(currentTime - 14.days))
+                        ]
+                    ])
+                ])
             ]
-            ]);
+        ]
+    ]);
 }


### PR DESCRIPTION
Fixes partly #494. If an array is inside parens, it gets the double identation of the parens and its own indentation. Instead the array indentation should override the parens, that indents the array elements correctly and the closing `])` as well.