### PR TITLE
Format multiline arrays first

### DIFF
--- a/src/dfmt/formatter.d
+++ b/src/dfmt/formatter.d
@@ -612,22 +612,7 @@ private:
         immutable bool arrayInitializerStart = p == tok!"["
             && astInformation.arrayStartLocations.canFindIndex(tokens[index - 1].index);
 
-        if (p == tok!"[" && config.dfmt_keep_line_breaks == OptionalBoolean.t)
-        {
-            IndentStack.Details detail;
-
-            detail.wrap = false;
-            detail.temp = false;
-            detail.breakEveryItem = false;
-            detail.mini = tokens[index].line == tokens[index - 1].line;
-
-            indents.push(tok!"]", detail);
-            if (!detail.mini)
-            {
-                newline();
-            }
-        }
-        else if (arrayInitializerStart && isMultilineAt(index - 1))
+        if (arrayInitializerStart && isMultilineAt(index - 1))
         {
             if (peekBack2Is(tok!"(")) {
                 indents.pop();
@@ -652,6 +637,21 @@ private:
             immutable size_t j = expressionEndIndex(index);
             linebreakHints = chooseLineBreakTokens(index, tokens[index .. j],
                     depths[index .. j], config, currentLineLength, indentLevel);
+        }
+        else if (p == tok!"[" && config.dfmt_keep_line_breaks == OptionalBoolean.t)
+        {
+            IndentStack.Details detail;
+
+            detail.wrap = false;
+            detail.temp = false;
+            detail.breakEveryItem = false;
+            detail.mini = tokens[index].line == tokens[index - 1].line;
+
+            indents.push(tok!"]", detail);
+            if (!detail.mini)
+            {
+                newline();
+            }
         }
         else if (arrayInitializerStart)
         {

--- a/tests/allman/keep_break_in_array_chain.d.ref
+++ b/tests/allman/keep_break_in_array_chain.d.ref
@@ -1,0 +1,7 @@
+unittest
+{
+    functionLengthDoesMatter([
+        firstFunctionInChain("A").seconFunctionInChain("B").value,
+        firstFunctionInChain("A").seconFunctionInChain("B").value
+    ]);
+}

--- a/tests/keep_break_in_array_chain.d
+++ b/tests/keep_break_in_array_chain.d
@@ -1,0 +1,7 @@
+unittest
+{
+    functionLengthDoesMatter([
+            firstFunctionInChain("A").seconFunctionInChain("B").value,
+            firstFunctionInChain("A").seconFunctionInChain("B").value
+            ]);
+}

--- a/tests/keep_break_in_array_chain.d.args
+++ b/tests/keep_break_in_array_chain.d.args
@@ -1,0 +1,1 @@
+--keep_line_breaks=true

--- a/tests/otbs/keep_break_in_array_chain.d.ref
+++ b/tests/otbs/keep_break_in_array_chain.d.ref
@@ -1,0 +1,6 @@
+unittest {
+    functionLengthDoesMatter([
+        firstFunctionInChain("A").seconFunctionInChain("B").value,
+        firstFunctionInChain("A").seconFunctionInChain("B").value
+    ]);
+}


### PR DESCRIPTION
This fixes an inconsistency between `--keep_line_breaks` and normal formatting, `--keep_line_breaks` inserts a newline in the UFCS chain (before `.value`), where the normal formatting doesn't.

```diff
@@ -1,7 +1,8 @@
 unittest
 {
     functionLengthDoesMatter([
-            firstFunctionInChain("A").seconFunctionInChain("B").value,
+            firstFunctionInChain("A").seconFunctionInChain("B")
+            .value,
             firstFunctionInChain("A").seconFunctionInChain("B").value
             ]);
 }
```