### PR TITLE
Upgrade libdparse to latest version

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -4,7 +4,7 @@
     "targetType": "autodetect",
     "license": "BSL-1.0",
     "dependencies": {
-      "libdparse": ">=0.14.0 <0.18.0"
+      "libdparse": ">=0.14.0 <1.0.0"
     },
     "targetPath" : "bin/",
     "targetName" : "dfmt",


### PR DESCRIPTION
This upgrade contains:

- alias assign recognition from the parser
- a memory corruption bug fix