### PR TITLE
Fix array literal indentation in foreach

### DIFF
--- a/src/dfmt/formatter.d
+++ b/src/dfmt/formatter.d
@@ -703,7 +703,10 @@ private:
     {
         if (parenDepthOnLine)
         {
-            indents.pop();
+            foreach (i; 0 .. parenDepthOnLine)
+            {
+                indents.pop();
+            }
             indents.popTempIndents();
         }
         parenDepthOnLine = 0;

--- a/tests/allman/foreach_array.d.ref
+++ b/tests/allman/foreach_array.d.ref
@@ -1,0 +1,39 @@
+static foreach (x; [
+    1,
+    2,
+    3,
+])
+{
+}
+
+static foreach_reverse (x; [
+    1,
+    2,
+    3,
+])
+{
+}
+
+void f()
+{
+    foreach (x; [
+        1,
+        2,
+        3,
+    ])
+    {
+    }
+    foreach_reverse (x; [
+        1,
+        2,
+        3,
+    ])
+    {
+    }
+
+    if (!SymbolTool.instance.workspacesFilesUris.canFind!sameFile(uri))
+    {
+        send(TextDocument.publishDiagnostics, new PublishDiagnosticsParams(uri, [
+        ]));
+    }
+}

--- a/tests/allman/foreach_array.d.ref
+++ b/tests/allman/foreach_array.d.ref
@@ -36,4 +36,19 @@ void f()
         send(TextDocument.publishDiagnostics, new PublishDiagnosticsParams(uri, [
         ]));
     }
+
+    foreach (x; map([
+        1,
+        2,
+        3,
+    ]))
+    {
+    }
+    foreach (x; foo!(map!([
+        1,
+        2,
+        3,
+    ])))
+    {
+    }
 }

--- a/tests/foreach_array.args
+++ b/tests/foreach_array.args
@@ -1,0 +1,1 @@
+--keep_line_breaks true

--- a/tests/foreach_array.d
+++ b/tests/foreach_array.d
@@ -35,4 +35,19 @@ void f()
     {
         send(TextDocument.publishDiagnostics, new PublishDiagnosticsParams(uri, []));
     }
+
+    foreach (x; map([
+            1,
+            2,
+            3,
+        ]))
+    {
+    }
+    foreach (x; foo!(map!([
+            1,
+            2,
+            3,
+        ])))
+    {
+    }
 }

--- a/tests/foreach_array.d
+++ b/tests/foreach_array.d
@@ -1,0 +1,38 @@
+static foreach (x; [
+    1,
+    2,
+    3,
+])
+{
+}
+
+static foreach_reverse (x; [
+    1,
+    2,
+    3,
+])
+{
+}
+
+void f()
+{
+    foreach (x; [
+        1,
+        2,
+        3,
+    ])
+    {
+    }
+    foreach_reverse (x; [
+        1,
+        2,
+        3,
+    ])
+    {
+    }
+
+    if (!SymbolTool.instance.workspacesFilesUris.canFind!sameFile(uri))
+    {
+        send(TextDocument.publishDiagnostics, new PublishDiagnosticsParams(uri, []));
+    }
+}

--- a/tests/knr/foreach_array.d.ref
+++ b/tests/knr/foreach_array.d.ref
@@ -1,0 +1,34 @@
+static foreach (x; [
+    1,
+    2,
+    3,
+]) {
+}
+
+static foreach_reverse (x; [
+    1,
+    2,
+    3,
+]) {
+}
+
+void f()
+{
+    foreach (x; [
+        1,
+        2,
+        3,
+    ]) {
+    }
+    foreach_reverse (x; [
+        1,
+        2,
+        3,
+    ]) {
+    }
+
+    if (!SymbolTool.instance.workspacesFilesUris.canFind!sameFile(uri)) {
+        send(TextDocument.publishDiagnostics, new PublishDiagnosticsParams(uri, [
+        ]));
+    }
+}

--- a/tests/knr/foreach_array.d.ref
+++ b/tests/knr/foreach_array.d.ref
@@ -31,4 +31,17 @@ void f()
         send(TextDocument.publishDiagnostics, new PublishDiagnosticsParams(uri, [
         ]));
     }
+
+    foreach (x; map([
+        1,
+        2,
+        3,
+    ])) {
+    }
+    foreach (x; foo!(map!([
+        1,
+        2,
+        3,
+    ]))) {
+    }
 }

--- a/tests/otbs/foreach_array.d.ref
+++ b/tests/otbs/foreach_array.d.ref
@@ -30,4 +30,17 @@ void f() {
         send(TextDocument.publishDiagnostics, new PublishDiagnosticsParams(uri, [
         ]));
     }
+
+    foreach (x; map([
+        1,
+        2,
+        3,
+    ])) {
+    }
+    foreach (x; foo!(map!([
+        1,
+        2,
+        3,
+    ]))) {
+    }
 }

--- a/tests/otbs/foreach_array.d.ref
+++ b/tests/otbs/foreach_array.d.ref
@@ -1,0 +1,33 @@
+static foreach (x; [
+    1,
+    2,
+    3,
+]) {
+}
+
+static foreach_reverse (x; [
+    1,
+    2,
+    3,
+]) {
+}
+
+void f() {
+    foreach (x; [
+        1,
+        2,
+        3,
+    ]) {
+    }
+    foreach_reverse (x; [
+        1,
+        2,
+        3,
+    ]) {
+    }
+
+    if (!SymbolTool.instance.workspacesFilesUris.canFind!sameFile(uri)) {
+        send(TextDocument.publishDiagnostics, new PublishDiagnosticsParams(uri, [
+        ]));
+    }
+}

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -5,6 +5,8 @@ for braceStyle in allman otbs knr
 do
 	for source in *.d
 	do
+		test "$(basename $source '.d')" = 'test' && continue
+
 		echo "${source}.ref" "${braceStyle}/${source}.out"
 		argsFile=$(basename "${source}" .d).args
 		if [ -e "${argsFile}" ]; then


### PR DESCRIPTION
This is a more generic fix for the array indentation problems in parens. It was already fixed for array literals in function arguments, but there are other places it still didn't work. e.g. `foreach` statements.

Here is the old formatting with `--keep_line_breaks`:

```d
    foreach (x; [
        1,
        2,
        3,
        ])
    {
    }
```

With this change the formatting is:

```d
    foreach (x; [
        1,
        2,
        3,
    ])
    {
    }
```

It also fixes the formatting of the last example in this issue https://github.com/dlang-community/dfmt/issues/435.

And I changed `test.sh` to ignore `test.d`, because currently `test.sh` is broken.