### PR TITLE
Fix else indentation after array literal

### DIFF
--- a/src/dfmt/indentation.d
+++ b/src/dfmt/indentation.d
@@ -278,6 +278,12 @@ private:
 
                 immutable currentIsNonWrapTemp = !details[i].wrap
                     && details[i].temp && arr[i] != tok!")" && arr[i] != tok!"!";
+
+                if (currentIsNonWrapTemp && arr[i + 1] == tok!"]")
+                {
+                    parenCount = pc;
+                    continue;
+                }
                 if (arr[i] == tok!"static"
                     && arr[i + 1].among!(tok!"if", tok!"else", tok!"foreach", tok!"foreach_reverse")
                     && (i + 2 >= index || arr[i + 2] != tok!"{"))

--- a/tests/allman/issue0494_else.d.ref
+++ b/tests/allman/issue0494_else.d.ref
@@ -1,0 +1,74 @@
+private void selectMember(Args...)(Args args)
+{
+    static if (true)
+    {
+        static if (args[0])
+        {
+        }
+        else
+        {
+        }
+    }
+    if (true)
+    {
+        if (args[0])
+        {
+        }
+        else
+        {
+        }
+    }
+}
+
+private void selectMember(Args...)(Args args)
+{
+    static if (true)
+    {
+        static if ([
+            0,
+            1,
+            2,
+            3,
+            4,
+        ])
+        {
+        }
+        else
+        {
+        }
+    }
+    if (true)
+    {
+        if (args[
+            0,
+            1,
+            2,
+            3,
+            4,
+        ])
+        {
+        }
+        else
+        {
+        }
+    }
+}
+
+void f()
+{
+    foreach (x; y)
+        if (foo)
+        {
+        }
+        else
+        {
+        }
+
+    if (a)
+        if (b)
+        {
+        }
+        else
+        {
+        }
+}

--- a/tests/issue0494_else.args
+++ b/tests/issue0494_else.args
@@ -1,0 +1,1 @@
+--keep_line_breaks=true

--- a/tests/issue0494_else.d
+++ b/tests/issue0494_else.d
@@ -1,0 +1,74 @@
+private void selectMember(Args...)(Args args)
+{
+    static if (true)
+    {
+        static if (args[0])
+        {
+        }
+        else
+        {
+        }
+    }
+    if (true)
+    {
+        if (args[0])
+        {
+        }
+        else
+        {
+        }
+    }
+}
+
+private void selectMember(Args...)(Args args)
+{
+    static if (true)
+    {
+        static if ([
+            0,
+            1,
+            2,
+            3,
+            4,
+        ])
+        {
+        }
+        else
+        {
+        }
+    }
+    if (true)
+    {
+        if (args[
+            0,
+            1,
+            2,
+            3,
+            4,
+        ])
+        {
+        }
+        else
+        {
+        }
+    }
+}
+
+void f()
+{
+    foreach (x; y)
+        if (foo)
+        {
+        }
+        else
+        {
+        }
+
+    if (a)
+        if (b)
+        {
+        }
+        else
+        {
+        }
+}

--- a/tests/knr/issue0494_else.d.ref
+++ b/tests/knr/issue0494_else.d.ref
@@ -1,0 +1,52 @@
+private void selectMember(Args...)(Args args)
+{
+    static if (true) {
+        static if (args[0]) {
+        } else {
+        }
+    }
+    if (true) {
+        if (args[0]) {
+        } else {
+        }
+    }
+}
+
+private void selectMember(Args...)(Args args)
+{
+    static if (true) {
+        static if ([
+            0,
+            1,
+            2,
+            3,
+            4,
+        ]) {
+        } else {
+        }
+    }
+    if (true) {
+        if (args[
+            0,
+            1,
+            2,
+            3,
+            4,
+        ]) {
+        } else {
+        }
+    }
+}
+
+void f()
+{
+    foreach (x; y)
+        if (foo) {
+        } else {
+        }
+
+    if (a)
+        if (b) {
+        } else {
+        }
+}

--- a/tests/otbs/issue0494_else.d.ref
+++ b/tests/otbs/issue0494_else.d.ref
@@ -1,0 +1,49 @@
+private void selectMember(Args...)(Args args) {
+    static if (true) {
+        static if (args[0]) {
+        } else {
+        }
+    }
+    if (true) {
+        if (args[0]) {
+        } else {
+        }
+    }
+}
+
+private void selectMember(Args...)(Args args) {
+    static if (true) {
+        static if ([
+            0,
+            1,
+            2,
+            3,
+            4,
+        ]) {
+        } else {
+        }
+    }
+    if (true) {
+        if (args[
+            0,
+            1,
+            2,
+            3,
+            4,
+        ]) {
+        } else {
+        }
+    }
+}
+
+void f() {
+    foreach (x; y)
+        if (foo) {
+        } else {
+        }
+
+    if (a)
+        if (b) {
+        } else {
+        }
+}


### PR DESCRIPTION
It is for bug introducted by me, where the `else` get incorrect indentation if `if` has an `[]` in the condition. For example:

```d
    if (true)
    {
        if (args[0])
        {
        }
    else
        {
        }
    }
```

(`else` tries to find the indentation of the last `if` but it is removed from the indentation stack).