### PR TITLE
always add potential spaces after `@attr`

### DIFF
--- a/src/dfmt/tokens.d
+++ b/src/dfmt/tokens.d
@@ -241,3 +241,10 @@ private string generateFixedLengthCases()
             a => format(`case tok!"%s": return %d;`, a, a.length)).join("\n\t");
     return spacedOperatorTokenCases ~ identifierTokenCases;
 }
+
+/// Returns true if the given token type is an identifier or a keyword that
+/// would be an identifier if it wasn't reserved.
+bool isLikeIdentifier(IdType t)
+{
+    return isKeyword(t) || isBasicType(t) || t == tok!"identifier";
+}

--- a/tests/allman/return_attr.d.ref
+++ b/tests/allman/return_attr.d.ref
@@ -1,0 +1,5 @@
+int foo() @nogc return
+{
+}
+
+int foo() @nogc in ()

--- a/tests/knr/return_attr.d.ref
+++ b/tests/knr/return_attr.d.ref
@@ -1,0 +1,5 @@
+int foo() @nogc return
+{
+}
+
+int foo() @nogc in ()

--- a/tests/otbs/return_attr.d.ref
+++ b/tests/otbs/return_attr.d.ref
@@ -1,0 +1,4 @@
+int foo() @nogc return {
+}
+
+int foo() @nogc in ()

--- a/tests/return_attr.d
+++ b/tests/return_attr.d
@@ -1,0 +1,5 @@
+int foo() @nogc return
+{
+}
+
+int foo() @nogc in ()

--- a/tests/test.d
+++ b/tests/test.d
@@ -12,10 +12,11 @@ version (Windows)
 else
     enum dfmt = `../bin/dfmt`;
 
-int main()
+int main(string[] args)
 {
+    string pattern = args.length == 2 ? args[1] : "*.d";
     foreach (braceStyle; ["allman", "otbs", "knr"])
-        foreach (entry; dirEntries(".", "*.d", SpanMode.shallow).filter!(e => e.baseName(".d") != "test"))
+        foreach (entry; dirEntries(".", pattern, SpanMode.shallow).filter!(e => e.baseName(".d") != "test"))
         {
             const source = entry.baseName;
             const outFileName = buildPath(braceStyle, source ~ ".out");


### PR DESCRIPTION
this uses a new `queueSpace` function, which inserts a space before writing the next token, unless we already had a newline inserted. This also fixes cases with double spaces.

This queueSpace function makes it much more resilient to grammar changes because we can put it in a lot more spaces without worrying about potentially inserting two spaces. It also catches more cases with keep_new_lines as every inserted space checks for if it should keep the existing new line at the current token.