### PR TITLE
Revert chain indentation in an argument list

### DIFF
--- a/src/dfmt/formatter.d
+++ b/src/dfmt/formatter.d
@@ -1625,6 +1625,10 @@ private:
             const commaLine = tokens[index].line;
 
             writeToken();
+            if (indents.topIs(tok!"."))
+            {
+                indents.pop;
+            }
             if (!currentIs(tok!")") && !currentIs(tok!"]")
                     && !currentIs(tok!"}") && !currentIs(tok!"comment"))
             {
@@ -1643,6 +1647,10 @@ private:
         {
             pushWrapIndent();
             writeToken();
+            if (indents.topIs(tok!"."))
+            {
+                indents.pop;
+            }
             newline();
         }
         else

--- a/tests/allman/argument_chain_indent.d.ref
+++ b/tests/allman/argument_chain_indent.d.ref
@@ -1,0 +1,13 @@
+class C
+{
+    void f()
+    {
+        if (true)
+        {
+            f(map.map.map.map.map.map.map.map.map.map.map.map.map.map.map.map
+                    .map.map.map.map.map.map, __FILE__, __FILE__, __FILE__, __FILE__, __FILE__,
+                __FILE__, __FILE__, __FILE__, __FILE__, __FILE__, __FILE__,
+                __FILE__, __FILE__, __FILE__, __FILE__, __FILE__, __LINE__);
+        }
+    }
+}

--- a/tests/allman/argument_chain_keep_breaks.d.ref
+++ b/tests/allman/argument_chain_keep_breaks.d.ref
@@ -1,0 +1,15 @@
+class C
+{
+    void f()
+    {
+        if (true)
+        {
+            f(
+                array.map!(a => a.prop)
+                    .array
+                    .to!string,
+                __FILE__,
+                __LINE__);
+        }
+    }
+}

--- a/tests/argument_chain_indent.args
+++ b/tests/argument_chain_indent.args
@@ -1,0 +1,1 @@
+--single_indent=true

--- a/tests/argument_chain_indent.d
+++ b/tests/argument_chain_indent.d
@@ -1,0 +1,28 @@
+class C
+{
+    void f()
+    {
+        if (true)
+        {
+            f(
+                map.map.map.map.map.map.map.map.map.map.map.map.map.map.map.map.map.map.map.map.map.map,
+                    __FILE__,
+                    __FILE__,
+                    __FILE__,
+                    __FILE__,
+                    __FILE__,
+                    __FILE__,
+                    __FILE__,
+                    __FILE__,
+                    __FILE__,
+                    __FILE__,
+                    __FILE__,
+                    __FILE__,
+                    __FILE__,
+                    __FILE__,
+                    __FILE__,
+                    __FILE__,
+                    __LINE__);
+        }
+    }
+}

--- a/tests/argument_chain_keep_breaks.args
+++ b/tests/argument_chain_keep_breaks.args
@@ -1,0 +1,2 @@
+--single_indent=true
+--keep_line_breaks=true

--- a/tests/argument_chain_keep_breaks.d
+++ b/tests/argument_chain_keep_breaks.d
@@ -1,0 +1,15 @@
+class C
+{
+    void f()
+    {
+        if (true)
+        {
+            f(
+                array.map!(a => a.prop)
+                    .array
+                    .to!string,
+                __FILE__,
+                __LINE__);
+        }
+    }
+}

--- a/tests/knr/argument_chain_indent.d.ref
+++ b/tests/knr/argument_chain_indent.d.ref
@@ -1,0 +1,11 @@
+class C {
+    void f()
+    {
+        if (true) {
+            f(map.map.map.map.map.map.map.map.map.map.map.map.map.map.map.map
+                    .map.map.map.map.map.map, __FILE__, __FILE__, __FILE__, __FILE__, __FILE__,
+                __FILE__, __FILE__, __FILE__, __FILE__, __FILE__, __FILE__,
+                __FILE__, __FILE__, __FILE__, __FILE__, __FILE__, __LINE__);
+        }
+    }
+}

--- a/tests/knr/argument_chain_keep_breaks.d.ref
+++ b/tests/knr/argument_chain_keep_breaks.d.ref
@@ -1,0 +1,13 @@
+class C {
+    void f()
+    {
+        if (true) {
+            f(
+                array.map!(a => a.prop)
+                    .array
+                    .to!string,
+                __FILE__,
+                __LINE__);
+        }
+    }
+}

--- a/tests/otbs/argument_chain_indent.d.ref
+++ b/tests/otbs/argument_chain_indent.d.ref
@@ -1,0 +1,10 @@
+class C {
+    void f() {
+        if (true) {
+            f(map.map.map.map.map.map.map.map.map.map.map.map.map.map.map.map
+                    .map.map.map.map.map.map, __FILE__, __FILE__, __FILE__, __FILE__, __FILE__,
+                __FILE__, __FILE__, __FILE__, __FILE__, __FILE__, __FILE__,
+                __FILE__, __FILE__, __FILE__, __FILE__, __FILE__, __LINE__);
+        }
+    }
+}

--- a/tests/otbs/argument_chain_keep_breaks.d.ref
+++ b/tests/otbs/argument_chain_keep_breaks.d.ref
@@ -1,0 +1,12 @@
+class C {
+    void f() {
+        if (true) {
+            f(
+                array.map!(a => a.prop)
+                    .array
+                    .to!string,
+                __FILE__,
+                __LINE__);
+        }
+    }
+}


### PR DESCRIPTION
Fixes the indentation of arguments after a function chain (see the tests for examples).

This fix works only with `--single_indent=true`. The reason is that function chains aren't aligned properly without `--single_indent`. For example the following code:

```d
class C {
    void f()
    {
        if (true) {
            f(
                    array.map!(a => a.prop)
                        .array
                        .to!string,
                    __FILE__,
                    __LINE__);
        }
    }
}
```

is formatted as

```d
class C
{
    void f()
    {
        if (true)
        {
            f(
                    array.map!(a => a.prop)
                    .array
                    .to!string,
                    __FILE__,
                    __LINE__);
        }
    }
}
```

So I think it is a different problem.