### PR TITLE
Revert operator indentation in an argument list

### DIFF
--- a/src/dfmt/formatter.d
+++ b/src/dfmt/formatter.d
@@ -1625,7 +1625,7 @@ private:
             const commaLine = tokens[index].line;
 
             writeToken();
-            if (indents.topIs(tok!"."))
+            if (indents.topIsWrap && !indents.topIs(tok!","))
             {
                 indents.pop;
             }
@@ -1647,7 +1647,7 @@ private:
         {
             pushWrapIndent();
             writeToken();
-            if (indents.topIs(tok!"."))
+            if (indents.topIsWrap && !indents.topIs(tok!","))
             {
                 indents.pop;
             }

--- a/tests/allman/argument_chain_indent.d.ref
+++ b/tests/allman/argument_chain_indent.d.ref
@@ -8,6 +8,16 @@ class C
                     .map.map.map.map.map.map, __FILE__, __FILE__, __FILE__, __FILE__, __FILE__,
                 __FILE__, __FILE__, __FILE__, __FILE__, __FILE__, __FILE__,
                 __FILE__, __FILE__, __FILE__, __FILE__, __FILE__, __LINE__);
+
+            g(map && map && map && map && map && map && map && map && map && map && map
+                    && map, __FILE__, __FILE__, __FILE__, __FILE__, __FILE__,
+                __FILE__, __FILE__, __LINE__);
+            h(map || map || map || map || map || map || map || map || map || map || map
+                    || map, __FILE__, __FILE__, __FILE__, __FILE__, __FILE__,
+                __FILE__, __FILE__, __LINE__);
+            i(map + map + map + map + map + map + map + map + map + map + map + map + map
+                    + map + map + map + map + map, __FILE__, __FILE__, __FILE__,
+                __FILE__, __FILE__, __FILE__, __FILE__, __LINE__);
         }
     }
 }

--- a/tests/allman/argument_chain_keep_breaks.d.ref
+++ b/tests/allman/argument_chain_keep_breaks.d.ref
@@ -10,6 +10,22 @@ class C
                     .to!string,
                 __FILE__,
                 __LINE__);
+
+            g(
+                map &&
+                    map,
+                __FILE__,
+                __LINE__);
+            h(
+                map ||
+                    map,
+                __FILE__,
+                __LINE__);
+            i(
+                map
+                    + map,
+                __FILE__,
+                __LINE__);
         }
     }
 }

--- a/tests/argument_chain_indent.d
+++ b/tests/argument_chain_indent.d
@@ -23,6 +23,38 @@ class C
                     __FILE__,
                     __FILE__,
                     __LINE__);
+
+            g(
+                map && map && map && map && map && map && map && map && map && map && map && map,
+                    __FILE__,
+                    __FILE__,
+                    __FILE__,
+                    __FILE__,
+                    __FILE__,
+                    __FILE__,
+                    __FILE__,
+                    __LINE__);
+            h(
+                map || map || map || map || map || map || map || map || map || map || map || map,
+                    __FILE__,
+                    __FILE__,
+                    __FILE__,
+                    __FILE__,
+                    __FILE__,
+                    __FILE__,
+                    __FILE__,
+                    __LINE__);
+            i(
+                map + map + map + map + map + map + map + map + map + map + map + map + map + map + map + map + map
+                    + map,
+                    __FILE__,
+                    __FILE__,
+                    __FILE__,
+                    __FILE__,
+                    __FILE__,
+                    __FILE__,
+                    __FILE__,
+                    __LINE__);
         }
     }
 }

--- a/tests/argument_chain_keep_breaks.d
+++ b/tests/argument_chain_keep_breaks.d
@@ -10,6 +10,22 @@ class C
                     .to!string,
                 __FILE__,
                 __LINE__);
+
+            g(
+                map &&
+                    map,
+                    __FILE__,
+                    __LINE__);
+            h(
+                map ||
+                    map,
+                    __FILE__,
+                    __LINE__);
+            i(
+                map
+                    + map,
+                    __FILE__,
+                    __LINE__);
         }
     }
 }

--- a/tests/knr/argument_chain_indent.d.ref
+++ b/tests/knr/argument_chain_indent.d.ref
@@ -6,6 +6,16 @@ class C {
                     .map.map.map.map.map.map, __FILE__, __FILE__, __FILE__, __FILE__, __FILE__,
                 __FILE__, __FILE__, __FILE__, __FILE__, __FILE__, __FILE__,
                 __FILE__, __FILE__, __FILE__, __FILE__, __FILE__, __LINE__);
+
+            g(map && map && map && map && map && map && map && map && map && map && map
+                    && map, __FILE__, __FILE__, __FILE__, __FILE__, __FILE__,
+                __FILE__, __FILE__, __LINE__);
+            h(map || map || map || map || map || map || map || map || map || map || map
+                    || map, __FILE__, __FILE__, __FILE__, __FILE__, __FILE__,
+                __FILE__, __FILE__, __LINE__);
+            i(map + map + map + map + map + map + map + map + map + map + map + map + map
+                    + map + map + map + map + map, __FILE__, __FILE__, __FILE__,
+                __FILE__, __FILE__, __FILE__, __FILE__, __LINE__);
         }
     }
 }

--- a/tests/knr/argument_chain_keep_breaks.d.ref
+++ b/tests/knr/argument_chain_keep_breaks.d.ref
@@ -8,6 +8,22 @@ class C {
                     .to!string,
                 __FILE__,
                 __LINE__);
+
+            g(
+                map &&
+                    map,
+                __FILE__,
+                __LINE__);
+            h(
+                map ||
+                    map,
+                __FILE__,
+                __LINE__);
+            i(
+                map
+                    + map,
+                __FILE__,
+                __LINE__);
         }
     }
 }

--- a/tests/otbs/argument_chain_indent.d.ref
+++ b/tests/otbs/argument_chain_indent.d.ref
@@ -5,6 +5,16 @@ class C {
                     .map.map.map.map.map.map, __FILE__, __FILE__, __FILE__, __FILE__, __FILE__,
                 __FILE__, __FILE__, __FILE__, __FILE__, __FILE__, __FILE__,
                 __FILE__, __FILE__, __FILE__, __FILE__, __FILE__, __LINE__);
+
+            g(map && map && map && map && map && map && map && map && map && map && map
+                    && map, __FILE__, __FILE__, __FILE__, __FILE__, __FILE__,
+                __FILE__, __FILE__, __LINE__);
+            h(map || map || map || map || map || map || map || map || map || map || map
+                    || map, __FILE__, __FILE__, __FILE__, __FILE__, __FILE__,
+                __FILE__, __FILE__, __LINE__);
+            i(map + map + map + map + map + map + map + map + map + map + map + map + map
+                    + map + map + map + map + map, __FILE__, __FILE__, __FILE__,
+                __FILE__, __FILE__, __FILE__, __FILE__, __LINE__);
         }
     }
 }

--- a/tests/otbs/argument_chain_keep_breaks.d.ref
+++ b/tests/otbs/argument_chain_keep_breaks.d.ref
@@ -7,6 +7,22 @@ class C {
                     .to!string,
                 __FILE__,
                 __LINE__);
+
+            g(
+                map &&
+                    map,
+                __FILE__,
+                __LINE__);
+            h(
+                map ||
+                    map,
+                __FILE__,
+                __LINE__);
+            i(
+                map
+                    + map,
+                __FILE__,
+                __LINE__);
         }
     }
 }


### PR DESCRIPTION
This is a follow-up for my previous pull request https://github.com/dlang-community/dfmt/pull/574. I discovered that hte same behaviour affects indentation of binary operators, and here is a fix of the same nature.