### PR TITLE
Keep "(" indentation with a "]" in the same line

### DIFF
--- a/src/dfmt/formatter.d
+++ b/src/dfmt/formatter.d
@@ -720,6 +720,12 @@ private:
 
     void revertParenIndentation()
     {
+        import std.algorithm.searching : canFind, until;
+
+        if (tokens[index .. $].until!(tok => tok.line != current.line).canFind!(x => x.type == tok!"]"))
+        {
+            return;
+        }
         if (parenDepthOnLine)
         {
             foreach (i; 0 .. parenDepthOnLine)

--- a/tests/allman/keep_break_in_array_arg.d.ref
+++ b/tests/allman/keep_break_in_array_arg.d.ref
@@ -4,3 +4,8 @@ unittest
         x
     ]);
 }
+
+void f(T[] x,
+        const U y)
+{
+}

--- a/tests/keep_break_in_array_arg.d
+++ b/tests/keep_break_in_array_arg.d
@@ -4,3 +4,8 @@ unittest
         x
     ]);
 }
+
+void f(T[] x,
+    const U y)
+{
+}

--- a/tests/knr/keep_break_in_array_arg.d.ref
+++ b/tests/knr/keep_break_in_array_arg.d.ref
@@ -3,3 +3,8 @@ unittest {
         x
     ]);
 }
+
+void f(T[] x,
+        const U y)
+{
+}

--- a/tests/otbs/keep_break_in_array_arg.d.ref
+++ b/tests/otbs/keep_break_in_array_arg.d.ref
@@ -3,3 +3,7 @@ unittest {
         x
     ]);
 }
+
+void f(T[] x,
+        const U y) {
+}


### PR DESCRIPTION
This a bugfix for d862d8aef1b46289be1fc7cf80809b70a734e8fa.  Basically, indentation is broken if one of the arguments contains `[]`, like here:

```d
void f(T[] x,
const U y)
{
}
```