### PR TITLE
bump minimum libdparse version, fix #583

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -4,7 +4,7 @@
     "targetType": "autodetect",
     "license": "BSL-1.0",
     "dependencies": {
-      "libdparse": ">=0.14.0 <1.0.0"
+      "libdparse": ">=0.19.2 <1.0.0"
     },
     "targetPath" : "bin/",
     "targetName" : "dfmt",


### PR DESCRIPTION
there was a bug in the ABI assumptions in the inline assembly.

I made a version using intrinsics, but since this works like this already, better just keep the inline assembly.