### PR TITLE
Fix issue #432

### DIFF
--- a/src/dfmt/formatter.d
+++ b/src/dfmt/formatter.d
@@ -1055,10 +1055,17 @@ private:
 
             // Account for possible function literals in this array which offset
             // the previously set index (pos). Fixes issue #432.
-            while(astInformation.indentInfoSortedByEndLocation[pos].endLocation !=
+            size_t newPos = pos;
+            while(astInformation.indentInfoSortedByEndLocation[newPos].endLocation <
                 tokens[index].index)
             {
-                pos++;
+                newPos++;
+            }
+
+            if (astInformation.indentInfoSortedByEndLocation[newPos].endLocation ==
+                tokens[index].index)
+            {
+                pos = newPos;
             }
 
             auto indentInfo = astInformation.indentInfoSortedByEndLocation[pos];

--- a/src/dfmt/formatter.d
+++ b/src/dfmt/formatter.d
@@ -1053,6 +1053,14 @@ private:
             if (niBraceDepth > 0)
                 niBraceDepth--;
 
+            // Account for possible function literals in this array which offset
+            // the previously set index (pos). Fixes issue #432.
+            while(astInformation.indentInfoSortedByEndLocation[pos].endLocation !=
+                tokens[index].index)
+            {
+                pos++;
+            }
+
             auto indentInfo = astInformation.indentInfoSortedByEndLocation[pos];
             if (indentInfo.flags & BraceIndentInfoFlags.tempIndent)
             {

--- a/tests/allman/issue0432.d.ref
+++ b/tests/allman/issue0432.d.ref
@@ -1,0 +1,17 @@
+struct S
+{
+    ulong x;
+    ulong y;
+    ulong z;
+    ulong w;
+}
+
+immutable int function(int) f = (x) { return x + 1111; };
+
+immutable S s = {
+    1111111111111111111, 1111111111111111111, 1111111111111111111, 1111111111111111111,
+};
+
+void main()
+{
+}

--- a/tests/allman/issue0432.d.ref
+++ b/tests/allman/issue0432.d.ref
@@ -1,4 +1,11 @@
-struct S
+struct S1
+{
+    ulong x;
+    ulong y;
+    ulong function(ulong) f;
+}
+
+struct S2
 {
     ulong x;
     ulong y;
@@ -6,12 +13,28 @@ struct S
     ulong w;
 }
 
-immutable int function(int) f = (x) { return x + 1111; };
+// -----------------------------------------------------------------------------
+// Example 1
+// Anonymous function in struct, long struct initializer
 
-immutable S s = {
+immutable S1 s1 = {
+    1111111111111111111, 1111111111111111111, (x) { return x + 1111; },
+};
+
+void f1()
+{
+}
+
+// -----------------------------------------------------------------------------
+// Example 2
+// Anonymous function anywhere, long struct initializer
+
+int function(int) f2 = (x) { return x + 1111; };
+
+immutable S2 s = {
     1111111111111111111, 1111111111111111111, 1111111111111111111, 1111111111111111111,
 };
 
-void main()
+void f2()
 {
 }

--- a/tests/issue0432.d
+++ b/tests/issue0432.d
@@ -1,0 +1,19 @@
+struct S
+{
+    ulong x;
+    ulong y;
+    ulong z;
+    ulong w;
+}
+
+immutable int function(int) f = (x) { return x + 1111; };
+
+immutable S s = {
+    1111111111111111111,
+    1111111111111111111,
+    1111111111111111111,
+    1111111111111111111,};
+
+    void main()
+    {
+    }

--- a/tests/issue0432.d
+++ b/tests/issue0432.d
@@ -1,4 +1,11 @@
-struct S
+struct S1
+{
+    ulong x;
+    ulong y;
+    ulong function(ulong)f;
+}
+
+struct S2
 {
     ulong x;
     ulong y;
@@ -6,14 +13,26 @@ struct S
     ulong w;
 }
 
-immutable int function(int) f = (x) { return x + 1111; };
+// -----------------------------------------------------------------------------
+// Example 1
+// Anonymous function in struct, long struct initializer
 
-immutable S s = {
-    1111111111111111111,
-    1111111111111111111,
-    1111111111111111111,
-    1111111111111111111,};
+immutable S1 s1 = {
+    1111111111111111111, 1111111111111111111, (x) { return x + 1111; },};
 
-    void main()
+    void f1()
+    {
+    }
+
+// -----------------------------------------------------------------------------
+// Example 2
+// Anonymous function anywhere, long struct initializer
+
+int function(int) f2 = (x) { return x + 1111; };
+
+immutable S2 s = {
+    1111111111111111111, 1111111111111111111, 1111111111111111111, 1111111111111111111,};
+
+    void f2()
     {
     }

--- a/tests/knr/issue0432.d.ref
+++ b/tests/knr/issue0432.d.ref
@@ -1,16 +1,38 @@
-struct S {
+struct S1 {
+    ulong x;
+    ulong y;
+    ulong function(ulong) f;
+}
+
+struct S2 {
     ulong x;
     ulong y;
     ulong z;
     ulong w;
 }
 
-immutable int function(int) f = (x) { return x + 1111; };
+// -----------------------------------------------------------------------------
+// Example 1
+// Anonymous function in struct, long struct initializer
 
-immutable S s = {
+immutable S1 s1 = {
+    1111111111111111111, 1111111111111111111, (x) { return x + 1111; },
+};
+
+void f1()
+{
+}
+
+// -----------------------------------------------------------------------------
+// Example 2
+// Anonymous function anywhere, long struct initializer
+
+int function(int) f2 = (x) { return x + 1111; };
+
+immutable S2 s = {
     1111111111111111111, 1111111111111111111, 1111111111111111111, 1111111111111111111,
 };
 
-void main()
+void f2()
 {
 }

--- a/tests/knr/issue0432.d.ref
+++ b/tests/knr/issue0432.d.ref
@@ -1,0 +1,16 @@
+struct S {
+    ulong x;
+    ulong y;
+    ulong z;
+    ulong w;
+}
+
+immutable int function(int) f = (x) { return x + 1111; };
+
+immutable S s = {
+    1111111111111111111, 1111111111111111111, 1111111111111111111, 1111111111111111111,
+};
+
+void main()
+{
+}

--- a/tests/otbs/issue0432.d.ref
+++ b/tests/otbs/issue0432.d.ref
@@ -1,15 +1,36 @@
-struct S {
+struct S1 {
+    ulong x;
+    ulong y;
+    ulong function(ulong) f;
+}
+
+struct S2 {
     ulong x;
     ulong y;
     ulong z;
     ulong w;
 }
 
-immutable int function(int) f = (x) { return x + 1111; };
+// -----------------------------------------------------------------------------
+// Example 1
+// Anonymous function in struct, long struct initializer
 
-immutable S s = {
+immutable S1 s1 = {
+    1111111111111111111, 1111111111111111111, (x) { return x + 1111; },
+};
+
+void f1() {
+}
+
+// -----------------------------------------------------------------------------
+// Example 2
+// Anonymous function anywhere, long struct initializer
+
+int function(int) f2 = (x) { return x + 1111; };
+
+immutable S2 s = {
     1111111111111111111, 1111111111111111111, 1111111111111111111, 1111111111111111111,
 };
 
-void main() {
+void f2() {
 }

--- a/tests/otbs/issue0432.d.ref
+++ b/tests/otbs/issue0432.d.ref
@@ -1,0 +1,15 @@
+struct S {
+    ulong x;
+    ulong y;
+    ulong z;
+    ulong w;
+}
+
+immutable int function(int) f = (x) { return x + 1111; };
+
+immutable S s = {
+    1111111111111111111, 1111111111111111111, 1111111111111111111, 1111111111111111111,
+};
+
+void main() {
+}


### PR DESCRIPTION
Overview:
Array astInformation.structInitEndLocations is used to find index to use in astInformation.indentInfoSortedByEndLocation.
Both are sorted, the first one is used to find the array index, the second one is accessed at that index to get brace indentation information.

Problem:
structInitEndLocations is generated from struct initializers exclusively while the brace information array also contains entries for function literal initializers. Thus when function literal init(s) are used, we get accumulating off by one errors in the second array:

match value in structInitEndLocations and take that index:
```
[3, 50]
    ^--> index 1
```

take brace indent information from that index (represented by the same offset values .endLocation):
```
[3, 15, 50]
    |   ^--> the one we want
    ^------> the one we get (function literal init)
```

If I missed something please let me know; also I am not 100% sure that I got the allman, knr, otbs examples right, but they look reasonable and throw no errors.

Better search strategies than linear are possible, this should be enough for any sane and most of the insane source files.