### PR TITLE
Fix issue #586

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ found there.
 * `--soft_max_line_length`: *see dfmt_soft_max_line_length [below](#dfmt-specific-properties)*
 * `--space_after_cast`: *see dfmt_space_after_cast [below](#dfmt-specific-properties)*
 * `--space_before_aa_colon`: *see dfmt_space_before_aa_colon [below](#dfmt-specific-properties)*
+* `--space_before_named_arg_colon`: *see dfmt_space_before_named_arg_colon [below](#dfmt-specific-properties)*
 * `--space_before_function_parameters`: *see dfmt_space_before_function_parameters [below](#dfmt-specific-properties)*
 * `--split_operator_at_line_end`: *see dfmt_split_operator_at_line_end [below](#dfmt-specific-properties)*
 * `--tab_width`: *see tab_width [below](#standard-editorconfig-properties)*
@@ -119,6 +120,7 @@ dfmt_compact_labeled_statements | **`true`**, `false` | Place labels on the same
 dfmt_template_constraint_style | **`conditional_newline_indent`** `conditional_newline` `always_newline` `always_newline_indent` | Control the formatting of template constraints.
 dfmt_single_template_constraint_indent | `true`, **`false`** | Set if the constraints are indented by a single tab instead of two. Has only an effect if the style set to `always_newline_indent` or `conditional_newline_indent`.
 dfmt_space_before_aa_colon | `true`, **`false`** | Adds a space after an associative array key before the `:` like in older dfmt versions.
+dfmt_space_before_named_arg_colon | `true`, **`false`** | Adds a space after a named function argument or named struct constructor argument before the `:`.
 dfmt_keep_line_breaks | `true`, **`false`** | Keep existing line breaks if these don't violate other formatting rules.
 dfmt_single_indent | `true`, **`false`** | Set if the code in parens is indented by a single tab instead of two.
 dfmt_reflow_property_chains | **`true`**, `false` | Recalculate the splitting of property chains into multiple lines.

--- a/src/dfmt/ast_info.d
+++ b/src/dfmt/ast_info.d
@@ -461,31 +461,22 @@ final class FormatVisitor : ASTVisitor
             return;
         }
 
-        /+
-        Items are function arguments: f(<item>, <item>);
-        Iterate them and check if they are named arguments: tok!":" belongs to a
-        named argument if it is preceeded by one tok!"identifier" (+ any number
-        of comments):
-        +/
         foreach (item; functionCall.arguments.namedArgumentList.items)
         {
-            // Set to true after first tok!"identifier".
-            auto foundIdentifier = false;
+            // Do nothing if not a named argument.
+            if (item.name == tok!"")
+            {
+                continue;
+            }
 
+            // Find first colon if named argument.
             foreach (t; item.tokens)
             {
-                if (t.type == tok!"identifier" && !foundIdentifier)
-                {
-                    foundIdentifier = true;
-                    continue;
-                }
-
-                if (t.type == tok!":" && foundIdentifier)
+                if (t.type == tok!":")
                 {
                     astInformation.namedArgumentColonLocations ~= t.index;
+                    break;
                 }
-
-                break;
             }
         }
 

--- a/src/dfmt/ast_info.d
+++ b/src/dfmt/ast_info.d
@@ -474,11 +474,6 @@ final class FormatVisitor : ASTVisitor
 
             foreach (t; item.tokens)
             {
-                if (t.type == tok!"comment")
-                {
-                    continue;
-                }
-
                 if (t.type == tok!"identifier" && !foundIdentifier)
                 {
                     foundIdentifier = true;

--- a/src/dfmt/config.d
+++ b/src/dfmt/config.d
@@ -67,6 +67,8 @@ struct Config
     OptionalBoolean dfmt_reflow_property_chains;
     ///
     OptionalBoolean dfmt_space_after_statement_keyword;
+    ///
+    OptionalBoolean dfmt_space_before_named_arg_colon;
 
     mixin StandardEditorConfigFields;
 
@@ -98,6 +100,7 @@ struct Config
         dfmt_keep_line_breaks = OptionalBoolean.f;
         dfmt_single_indent = OptionalBoolean.f;
         dfmt_reflow_property_chains = OptionalBoolean.t;
+        dfmt_space_before_named_arg_colon = OptionalBoolean.f;
     }
 
     /**

--- a/src/dfmt/formatter.d
+++ b/src/dfmt/formatter.d
@@ -835,13 +835,13 @@ private:
     {
         import dfmt.editorconfig : OptionalBoolean;
         import std.algorithm : canFind, any;
-
         immutable bool isCase = astInformation.caseEndLocations.canFindIndex(current.index);
         immutable bool isAttribute = astInformation.attributeDeclarationLines.canFindIndex(
                 current.line);
         immutable bool isStructInitializer = astInformation.structInfoSortedByEndLocation
             .canFind!(st => st.startLocation < current.index && current.index < st.endLocation);
         immutable bool isTernary = astInformation.ternaryColonLocations.canFindIndex(current.index);
+        immutable bool isNamedArg = astInformation.namedArgumentColonLocations.canFindIndex(current.index);
 
         if (isCase || isAttribute)
         {
@@ -860,6 +860,12 @@ private:
         else if (indents.topIs(tok!"]") && !isTernary) // Associative array
         {
             write(config.dfmt_space_before_aa_colon ? " : " : ": ");
+            ++index;
+        }
+        // Named function or struct constructor arguments.
+        else if (isNamedArg)
+        {
+            write(config.dfmt_space_before_named_arg_colon ? " : " : ": ");
             ++index;
         }
         else if (peekBackIs(tok!"identifier")

--- a/src/dfmt/main.d
+++ b/src/dfmt/main.d
@@ -92,6 +92,9 @@ else
             case "space_before_aa_colon":
                 optConfig.dfmt_space_before_aa_colon = optVal;
                 break;
+            case "space_before_named_arg_colon":
+                optConfig.dfmt_space_before_named_arg_colon = optVal;
+                break;
             case "keep_line_breaks":
                 optConfig.dfmt_keep_line_breaks = optVal;
                 break;
@@ -133,6 +136,7 @@ else
                 "compact_labeled_statements", &handleBooleans,
                 "single_template_constraint_indent", &handleBooleans,
                 "space_before_aa_colon", &handleBooleans,
+                "space_before_named_arg_colon", &handleBooleans,
                 "tab_width", &optConfig.tab_width,
                 "template_constraint_style", &optConfig.dfmt_template_constraint_style,
                 "keep_line_breaks", &handleBooleans,
@@ -349,6 +353,7 @@ Formatting Options:
     --compact_labeled_statements
     --template_constraint_style
     --space_before_aa_colon
+    --space_before_named_arg_colon
     --single_indent
     --reflow_property_chains
         `,

--- a/tests/allman/issue0586.d.ref
+++ b/tests/allman/issue0586.d.ref
@@ -1,0 +1,28 @@
+void temp(int v1, int v2)
+{
+}
+
+int f(int i)
+{
+    return i;
+}
+
+struct S
+{
+    int i;
+    int j;
+}
+
+void main()
+{
+    temp(v1: 1, v2: 2);
+    temp(v1: 1, v2: 2,);
+
+    auto s = S(5, j: 3);
+
+    temp(v1: 1, v2: f(i: 2));
+
+    temp(v1: true ? i : false ? 2 : f(i: 3), v2: 4);
+
+    temp(v1: () { S s = S(i: 5); return s.i; }, v2: 1);
+}

--- a/tests/issue0586.d
+++ b/tests/issue0586.d
@@ -1,0 +1,31 @@
+void temp(int v1, int v2)
+{
+}
+
+int f(int i)
+{
+    return i;
+}
+
+struct S
+{
+    int i;
+    int j;
+}
+
+void main()
+{
+    temp(v1: 1, v2: 2);
+    temp(
+        v1: 1,
+        v2: 2,
+    );
+
+    auto s = S(5, j: 3);
+
+    temp(v1: 1, v2: f(i: 2));
+
+    temp(v1: true ? i : false ? 2 : f(i: 3), v2: 4);
+
+    temp(v1: () { S s = S(i: 5); return s.i; }, v2: 1);
+}

--- a/tests/knr/issue0586.d.ref
+++ b/tests/knr/issue0586.d.ref
@@ -1,0 +1,27 @@
+void temp(int v1, int v2)
+{
+}
+
+int f(int i)
+{
+    return i;
+}
+
+struct S {
+    int i;
+    int j;
+}
+
+void main()
+{
+    temp(v1: 1, v2: 2);
+    temp(v1: 1, v2: 2,);
+
+    auto s = S(5, j: 3);
+
+    temp(v1: 1, v2: f(i: 2));
+
+    temp(v1: true ? i : false ? 2 : f(i: 3), v2: 4);
+
+    temp(v1: () { S s = S(i: 5); return s.i; }, v2: 1);
+}

--- a/tests/otbs/issue0586.d.ref
+++ b/tests/otbs/issue0586.d.ref
@@ -1,0 +1,24 @@
+void temp(int v1, int v2) {
+}
+
+int f(int i) {
+    return i;
+}
+
+struct S {
+    int i;
+    int j;
+}
+
+void main() {
+    temp(v1: 1, v2: 2);
+    temp(v1: 1, v2: 2,);
+
+    auto s = S(5, j: 3);
+
+    temp(v1: 1, v2: f(i: 2));
+
+    temp(v1: true ? i : false ? 2 : f(i: 3), v2: 4);
+
+    temp(v1: () { S s = S(i: 5); return s.i; }, v2: 1);
+}


### PR DESCRIPTION
Feature from this implementation: handles struct initialisers with named arguments the same way as named function arguments (removing this might be difficult, also I think this is probably good for consistency):
```d
struct S { int i; }
void f(int i) {}
void main() {
    // both become this
    f(i: 1); auto s = S(i: 1);
    // or this
    f(i : 1); auto s = S(i : 1);
}
```

The multiline example from issue 586 is rewritten to one line if `--keep_line_breaks=false` which is not an error of the `:` formatting and / or expected behaviour (?) since the combined line is still rather short.
If `--keep_line_breaks=true` the argument indentation is wrong: but this shouldn't be related to `:` formatting and probably requires its own issue (if there isn't one yet):
```d
void main()
{
    f(
        v1: 1,
        v2: 2,
    );
}
```
becomes (with `--keep_line_breaks=true`)
```d
void main()
{
    f(
v1: 1,
v2: 2,
    );
}
```

\
There are no examples for
* comments around the function argument `f(/+ abc +/ i /+ def +/: 1);` since issue 565 messes with the result (the `:` part works as expected but tests will fail if 565 gets fixed).
* multiline anon func examples or similar multiline `{}` blocks inside the function call due to issues with indentation afterwards (probably related to issue 545).