### PR TITLE
Improve makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,53 +1,64 @@
+PREFIX = /usr/local
+
 SRC := $(shell find src -name "*.d") \
 	$(shell find libdparse/src -name "*.d") \
 	$(shell find stdx-allocator/source -name "*.d")
-INCLUDE_PATHS := -Ilibdparse/src -Istdx-allocator/source -Isrc -Jbin
-DMD_COMMON_FLAGS := -dip25 -w $(INCLUDE_PATHS)
-DMD_DEBUG_FLAGS := -debug -g $(DMD_COMMON_FLAGS)
-DMD_FLAGS := -O -inline $(DMD_COMMON_FLAGS)
-DMD_TEST_FLAGS := -unittest -g $(DMD_COMMON_FLAGS)
-LDC_FLAGS := -g -w -oq $(INCLUDE_PATHS)
-GDC_FLAGS := -g -w -oq $(INCLUDE_PATHS)
-override DMD_FLAGS += $(DFLAGS)
-override LDC_FLAGS += $(DFLAGS)
-override GDC_FLAGS += $(DFLAGS)
+IMPORTS := -Ilibdparse/src -Istdx-allocator/source -Isrc -Jbin
+
 DC ?= dmd
 LDC ?= ldc2
 GDC ?= gdc
 
-.PHONY: dmd ldc gdc test
+DMD_COMMON_FLAGS := -w $(IMPORTS)
+DMD_DEBUG_FLAGS := -debug -g $(DMD_COMMON_FLAGS)
+DMD_FLAGS := -O -inline $(DMD_COMMON_FLAGS)
+DMD_TEST_FLAGS := -unittest -g $(DMD_COMMON_FLAGS)
+LDC_FLAGS := -g -w -oq $(IMPORTS)
+GDC_FLAGS := -g -w -oq $(IMPORTS)
+override DMD_FLAGS += $(DFLAGS)
+override LDC_FLAGS += $(DFLAGS)
+override GDC_FLAGS += $(DFLAGS)
 
-dmd: bin/dfmt
+.PHONY: all clean install debug dmd ldc gdc pkg release test
 
-githash:
+all: bin/dfmt
+
+bin/githash.txt:
 	mkdir -p bin
 	git describe --tags > bin/githash.txt
 
-ldc: githash
+dmd: bin/dfmt
+
+ldc: bin/githash.txt
 	$(LDC) $(SRC) $(LDC_FLAGS) -ofbin/dfmt
 	-rm -f *.o
 
-gdc:githash
+gdc: bin/githash.txt
 	$(GDC) $(SRC) $(GDC_FLAGS) -obin/dfmt
 
 test: debug
 	cd tests && ./test.d
 
-bin/dfmt-test: githash $(SRC)
+bin/dfmt-test: bin/githash.txt $(SRC)
 	$(DC) $(DMD_TEST_FLAGS) $^ -of$@
 
-bin/dfmt: githash $(SRC)
+bin/dfmt: bin/githash.txt $(SRC)
 	$(DC) $(DMD_FLAGS) $(filter %.d,$^) -of$@
 
-debug: githash $(SRC)
+debug: bin/githash.txt $(SRC)
 	$(DC) $(DMD_DEBUG_FLAGS) $(filter %.d,$^) -ofbin/dfmt
 
 pkg: dmd
 	$(MAKE) -f makd/Makd.mak pkg
 
 clean:
-	$(RM) bin/dfmt
+	$(RM) bin/dfmt bin/dfmt-test bin/githash.txt
+
+install:
+	chmod +x bin/dfmt
+	mkdir -p $(DESTDIR)$(PREFIX)/bin
+	cp -f bin/dfmt $(DESTDIR)$(PREFIX)/bin/dfmt
 
 release:
 	./release.sh
-	githash
+	$(MAKE) bin/githash.txt


### PR DESCRIPTION
Improve makefile by adding an `install` target and using filename prerequisities over phony targets. Full list of changes from the commit message:

>  -  add 'install' target
>  -  shorten the name of INCLUDE_PATHS to IMPORTS
>  -  use filename prerequisities and targets rather than phony keywords
>  -  add a dependency on .git/refs/tags for the githash target
>  -  add githash.txt and dfmt-test to the clean target
>  -  add more targets to .PHONY