### PR TITLE
remove explicit `nothrow` from `globMatchEditorConfig`

### DIFF
--- a/src/dfmt/globmatch_editorconfig.d
+++ b/src/dfmt/globmatch_editorconfig.d
@@ -12,7 +12,7 @@ import std.path : filenameCharCmp, isDirSeparator;
 // * changes meaning to match all characters except '/'
 // ** added to take over the old meaning of *
 bool globMatchEditorConfig(CaseSensitive cs = CaseSensitive.osDefault, C, Range)(
-        Range path, const(C)[] pattern) @safe pure nothrow
+        Range path, const(C)[] pattern) @safe pure
         if (isForwardRange!Range && isSomeChar!(ElementEncodingType!Range)
             && isSomeChar!C && is(Unqual!C == Unqual!(ElementEncodingType!Range)))
 in


### PR DESCRIPTION
The in contract may throw. Fixes #603